### PR TITLE
[Issue#3] Add server response content to property bag.

### DIFF
--- a/src/XPing365.Sdk.Availability/TestSteps/IPAddressAccessibilityCheck.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/IPAddressAccessibilityCheck.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using System.Net.NetworkInformation;
 using System.Text;
-using XPing365.Sdk.Availability.Extensions;
+using XPing365.Sdk.Availability.TestSteps.Internals;
 using XPing365.Sdk.Core;
 using XPing365.Sdk.Shared;
 

--- a/src/XPing365.Sdk.Availability/TestSteps/Internals/HttpResponseMessageExtension.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/Internals/HttpResponseMessageExtension.cs
@@ -3,7 +3,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using XPing365.Sdk.Core;
 
-namespace XPing365.Sdk.Availability.Extensions;
+namespace XPing365.Sdk.Availability.TestSteps.Internals;
 
 internal static class HttpResponseMessageExtension
 {
@@ -17,7 +17,7 @@ internal static class HttpResponseMessageExtension
             { PropertyBagKeys.HttpReasonPhrase, httpResponse.ReasonPhrase ?? string.Empty },
             { PropertyBagKeys.HttpVersion, httpResponse.Version },
             { PropertyBagKeys.HttpResponseHeaders, httpResponse.Headers },
-            { PropertyBagKeys.HttpResponseTrailingHeaders, httpResponse.TrailingHeaders },
+            { PropertyBagKeys.HttpResponseTrailingHeaders, httpResponse.TrailingHeaders }
         };
 
         return properties;
@@ -46,7 +46,7 @@ internal static class HttpResponseMessageExtension
                         {
                             sb.Append(',');
                         }
-                        
+
                         sb.AppendFormat(CultureInfo.InvariantCulture, "{0}", header.Key);
                         sb.Append(": ");
                         sb.AppendFormat(CultureInfo.InvariantCulture, "{0}", headerValue);

--- a/src/XPing365.Sdk.Availability/TestSteps/Internals/IPAddressExtension.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/Internals/IPAddressExtension.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using System.Net.Sockets;
 
-namespace XPing365.Sdk.Availability.Extensions;
+namespace XPing365.Sdk.Availability.TestSteps.Internals;
 
 internal static class IPAddressExtension
 {

--- a/src/XPing365.Sdk.Availability/TestSteps/Internals/IPStatusExtension.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/Internals/IPStatusExtension.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using System.Net.NetworkInformation;
 
-namespace XPing365.Sdk.Availability.Extensions;
+namespace XPing365.Sdk.Availability.TestSteps.Internals;
 
 internal static class IPStatusExtension
 {
@@ -20,7 +20,7 @@ internal static class IPStatusExtension
                 "computer is not reachable.",
             IPStatus.DestinationProhibited => address.IsIPv6() ?
                 "The ICMPv6 echo request failed because contact with the destination " +
-                "computer is administratively prohibited. This value applies only to IPv6. " : 
+                "computer is administratively prohibited. This value applies only to IPv6. " :
                 "The ICMP echo request failed because the destination computer that is specified " +
                 "in an ICMP echo message is not reachable, because it does not support the packet's " +
                 "protocol. This value applies only to IPv4. This value is described in IETF RFC " +
@@ -30,19 +30,19 @@ internal static class IPStatusExtension
             IPStatus.NoResources => "The ICMP echo request failed because of insufficient network resources.",
             IPStatus.BadOption => "The ICMP echo request failed because it contains an invalid option.",
             IPStatus.HardwareError => "The ICMP echo request failed because of a hardware error.",
-            IPStatus.PacketTooBig => 
+            IPStatus.PacketTooBig =>
                 "The ICMP echo request failed because the packet containing the request is larger " +
                 "than the maximum transmission unit (MTU) of a node (router or gateway) located " +
                 "between the source and destination. The MTU defines the maximum size of a transmittable " +
                 "packet.",
             IPStatus.TimedOut => "The ICMP echo Reply was not received within the allotted time.",
-            IPStatus.BadRoute => 
+            IPStatus.BadRoute =>
                 "The ICMP echo request failed because there is no valid route between the source " +
                 "and destination computers.",
-            IPStatus.TtlExpired => 
+            IPStatus.TtlExpired =>
                 "The ICMP echo request failed because its Time to Live (TTL) value reached zero, " +
                 "causing the forwarding node (router or gateway) to discard the packet.",
-            IPStatus.TtlReassemblyTimeExceeded => 
+            IPStatus.TtlReassemblyTimeExceeded =>
                 "The ICMP echo request failed because the packet was divided into fragments for " +
                 "transmission and all of the fragments were not received within the time allotted " +
                 "for reassembly. RFC 2460 specifies 60 seconds as the time limit within which " +
@@ -66,7 +66,7 @@ internal static class IPStatusExtension
                 "The ICMP echo request failed because its Time to Live (TTL) value reached zero, " +
                 "causing the forwarding node (router or gateway) to discard the packet.",
             IPStatus.BadHeader => "The ICMP echo request failed because the header is invalid.",
-            IPStatus.UnrecognizedNextHeader => 
+            IPStatus.UnrecognizedNextHeader =>
                 "The ICMP echo request failed because the Next Header field does not contain a " +
                 "recognized value. The Next Header field indicates the extension header type (if " +
                 "present) or the protocol above the IP layer, for example, TCP or UDP. ",

--- a/src/XPing365.Sdk.Availability/TestSteps/Internals/PingReplyExtension.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/Internals/PingReplyExtension.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net.NetworkInformation;
 using XPing365.Sdk.Core;
 
-namespace XPing365.Sdk.Availability.Extensions;
+namespace XPing365.Sdk.Availability.TestSteps.Internals;
 
 internal static class PingReplyExtension
 {

--- a/src/XPing365.Sdk.Availability/TestSteps/SendHttpRequest.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/SendHttpRequest.cs
@@ -1,11 +1,6 @@
-﻿using System.Runtime.Intrinsics.X86;
-using System.Text;
-using System;
-using XPing365.Sdk.Availability.Extensions;
-using XPing365.Sdk.Availability.TestSteps.Internals;
+﻿using XPing365.Sdk.Availability.TestSteps.Internals;
 using XPing365.Sdk.Core;
 using XPing365.Sdk.Shared;
-using System.Threading;
 
 namespace XPing365.Sdk.Availability.TestSteps;
 

--- a/src/XPing365.Sdk.Availability/TestSteps/SendHttpRequest.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/SendHttpRequest.cs
@@ -88,16 +88,16 @@ public sealed class SendHttpRequest(IHttpClientFactory httpClientFactory) :
     }
 
     private HttpClient CreateHttpClient(TestSettings settings)
-{
-    HttpClient httpClient = null!;
-    if (settings.RetryHttpRequestWhenFailed == true && settings.FollowHttpRedirectionResponses == true)
     {
-        httpClient = _httpClientFactory.CreateClient(HttpClientWithRetryAndFollowRedirect);
-    }
-    else if (settings.RetryHttpRequestWhenFailed == true && settings.FollowHttpRedirectionResponses == false)
-    {
-        httpClient = _httpClientFactory.CreateClient(HttpClientWithRetryAndNoFollowRedirect);
-    }
+        HttpClient httpClient = null!;
+        if (settings.RetryHttpRequestWhenFailed == true && settings.FollowHttpRedirectionResponses == true)
+        {
+            httpClient = _httpClientFactory.CreateClient(HttpClientWithRetryAndFollowRedirect);
+        }
+        else if (settings.RetryHttpRequestWhenFailed == true && settings.FollowHttpRedirectionResponses == false)
+        {
+            httpClient = _httpClientFactory.CreateClient(HttpClientWithRetryAndNoFollowRedirect);
+        }
         else if (settings.RetryHttpRequestWhenFailed == false && settings.FollowHttpRedirectionResponses == false)
         {
             httpClient = _httpClientFactory.CreateClient(HttpClientWithNoRetryAndNoFollowRedirect);

--- a/src/XPing365.Sdk.Availability/TestSteps/SendHttpRequest.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/SendHttpRequest.cs
@@ -1,6 +1,11 @@
-﻿using XPing365.Sdk.Availability.Extensions;
+﻿using System.Runtime.Intrinsics.X86;
+using System.Text;
+using System;
+using XPing365.Sdk.Availability.Extensions;
+using XPing365.Sdk.Availability.TestSteps.Internals;
 using XPing365.Sdk.Core;
 using XPing365.Sdk.Shared;
+using System.Threading;
 
 namespace XPing365.Sdk.Availability.TestSteps;
 
@@ -54,11 +59,13 @@ public sealed class SendHttpRequest(IHttpClientFactory httpClientFactory) :
         TestStep testStep = null!;
         try
         {
-            HttpResponseMessage response = await httpClient
+            using HttpResponseMessage response = await httpClient
                 .SendAsync(request, cancellationToken)
                 .ConfigureAwait(false);
 
             var propertyBag = new PropertyBag(response.ToProperties());
+            byte[] buffer = await ReadAsByteArrayAsync(response.Content, cancellationToken).ConfigureAwait(false);
+            propertyBag.AddOrUpdateProperty(PropertyBagKeys.HttpContent, buffer);
             testStep = CreateSuccessTestStep(inst.StartTime, inst.ElapsedTime, propertyBag);
         }
         catch (Exception exception)
@@ -69,18 +76,28 @@ public sealed class SendHttpRequest(IHttpClientFactory httpClientFactory) :
         return testStep;
     }
 
-    private HttpClient CreateHttpClient(TestSettings settings)
+    private static async Task<byte[]> ReadAsByteArrayAsync(HttpContent httpContent, CancellationToken cancellationToken)
     {
-        HttpClient httpClient = null!;
+        // When storing the server response content, it is generally recommended to store it as a byte array
+        // rather than a string. This is because the response content may contain binary data that cannot be represented
+        // as a string.
 
-        if (settings.RetryHttpRequestWhenFailed == true && settings.FollowHttpRedirectionResponses == true)
-        {
-            httpClient = _httpClientFactory.CreateClient(HttpClientWithRetryAndFollowRedirect);
-        }
-        else if (settings.RetryHttpRequestWhenFailed == true && settings.FollowHttpRedirectionResponses == false)
-        {
-            httpClient = _httpClientFactory.CreateClient(HttpClientWithRetryAndNoFollowRedirect);
-        }
+        // If you need to convert the byte array to a string for display purposes, you can use the Encoding class to
+        // specify the character encoding to use.
+        return await httpContent.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private HttpClient CreateHttpClient(TestSettings settings)
+{
+    HttpClient httpClient = null!;
+    if (settings.RetryHttpRequestWhenFailed == true && settings.FollowHttpRedirectionResponses == true)
+    {
+        httpClient = _httpClientFactory.CreateClient(HttpClientWithRetryAndFollowRedirect);
+    }
+    else if (settings.RetryHttpRequestWhenFailed == true && settings.FollowHttpRedirectionResponses == false)
+    {
+        httpClient = _httpClientFactory.CreateClient(HttpClientWithRetryAndNoFollowRedirect);
+    }
         else if (settings.RetryHttpRequestWhenFailed == false && settings.FollowHttpRedirectionResponses == false)
         {
             httpClient = _httpClientFactory.CreateClient(HttpClientWithNoRetryAndNoFollowRedirect);

--- a/src/XPing365.Sdk.Availability/Validators/HttpResponseHeadersValidator.cs
+++ b/src/XPing365.Sdk.Availability/Validators/HttpResponseHeadersValidator.cs
@@ -61,9 +61,6 @@ public class HttpResponseHeadersValidator(
         HttpResponseHeaders responseHeaders = 
             sendHttpRequestStep.PropertyBag.GetProperty<HttpResponseHeaders>(
                 PropertyBagKeys.HttpResponseHeaders);
-        HttpResponseHeaders responseTrailingHeaders =
-            sendHttpRequestStep.PropertyBag.GetProperty<HttpResponseHeaders>(
-                PropertyBagKeys.HttpResponseTrailingHeaders);
 
         using var inst = new InstrumentationLog();
         TestStep testStep = null!;

--- a/tests/XPing365.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
@@ -1,8 +1,4 @@
-
-using System;
-using System.Collections;
 using System.Net;
-using System.Net.Mail;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;

--- a/tests/XPing365.Sdk.IntegrationTests/HttpServer/InMemoryHttpServer.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/HttpServer/InMemoryHttpServer.cs
@@ -16,7 +16,7 @@ internal static class InMemoryHttpServer
         Action<HttpListenerRequest> requestReceived,
         CancellationToken cancellationToken = default)
     {
-        return Task.Factory.StartNew(() =>
+        return Task.Run(() =>
         {
             using HttpListener listener = new();
             listener.Prefixes.Add(GetTestServerAddress().AbsoluteUri);
@@ -29,8 +29,8 @@ internal static class InMemoryHttpServer
             responseBuilder(context.Response);
             // Wait for the receiver of the response to read the stream.
             // Cancelled token exits the Task.Delay without having to wait longer than is necessary.
-            Task.Delay(millisecondsDelay: 1000, cancellationToken);
-        }, cancellationToken, TaskCreationOptions.None, TaskScheduler.Default);
+            Task.Delay(millisecondsDelay: 100, cancellationToken);
+        }, cancellationToken);
     }
 
     public static Uri GetTestServerAddress()


### PR DESCRIPTION
This pull request adds server response content to the `PropertyBag` of the `TestSession`. The current implementation of the `TestSession` does not include server response content in the `PropertyBag`, which makes it difficult to debug issues related to server availability. By modifying the `TestSession` to include server response content in the `PropertyBag`, we can easily identify the root cause of server availability issues.

**Changes Made:**

Added server response content to the `PropertyBag` of the `TestSession` as part of the `SendHttpRequest` test step.

**Testing:**

Created and ran integration test to ensure that the modified `TestSession` works as expected.