### PR TITLE
Add ServerResponseContentValidator class

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The library is distributed as a [NuGet packages](https://www.nuget.org/profiles/
 4. Once the package is installed, you can start using the <b>XPing365</b> library in your project.
 
 ```c#
-using XPing365.Availability.Extensions;
+using XPing365.Availability.DependencyInjection;
 
 Host.CreateDefaultBuilder()
     .ConfigureServices(services =>

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -18,7 +18,7 @@ The library is distributed as a [NuGet packages](https://www.nuget.org/profiles/
 4. Once the package is installed, you can start using the <b>XPing365</b> library in your project.
 
 ```c#
-using XPing365.Availability.Extensions;
+using XPing365.Availability.DependencyInjection;
 
 Host.CreateDefaultBuilder()
     .ConfigureServices(services =>

--- a/nuspec/README.md
+++ b/nuspec/README.md
@@ -26,7 +26,7 @@ The library is distributed as a [NuGet packages](https://www.nuget.org/profiles/
 4. Once the package is installed, you can start using the <b>XPing365</b> library in your project.
 
 ```c#
-using XPing365.Availability.Extensions;
+using XPing365.Availability.DependencyInjection;
 
 Host.CreateDefaultBuilder()
     .ConfigureServices(services =>

--- a/src/XPing365.Sdk.Availability/DependencyInjection/DependencyInjectionExtension.cs
+++ b/src/XPing365.Sdk.Availability/DependencyInjection/DependencyInjectionExtension.cs
@@ -3,7 +3,7 @@ using Polly;
 using XPing365.Sdk.Availability.Configurations;
 using XPing365.Sdk.Availability.TestSteps;
 
-namespace XPing365.Sdk.Availability.Extensions;
+namespace XPing365.Sdk.Availability.DependencyInjection;
 
 public static class DependencyInjectionExtension
 {

--- a/src/XPing365.Sdk.Availability/TestSteps/Internals/HttpResponseMessageExtension.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/Internals/HttpResponseMessageExtension.cs
@@ -17,7 +17,8 @@ internal static class HttpResponseMessageExtension
             { PropertyBagKeys.HttpReasonPhrase, httpResponse.ReasonPhrase ?? string.Empty },
             { PropertyBagKeys.HttpVersion, httpResponse.Version },
             { PropertyBagKeys.HttpResponseHeaders, httpResponse.Headers },
-            { PropertyBagKeys.HttpResponseTrailingHeaders, httpResponse.TrailingHeaders }
+            { PropertyBagKeys.HttpResponseTrailingHeaders, httpResponse.TrailingHeaders },
+            { PropertyBagKeys.HttpContentHeaders, httpResponse.Content.Headers }
         };
 
         return properties;

--- a/src/XPing365.Sdk.Availability/TestSteps/SendHttpRequest.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/SendHttpRequest.cs
@@ -57,7 +57,6 @@ public sealed class SendHttpRequest(IHttpClientFactory httpClientFactory) :
             using HttpResponseMessage response = await httpClient
                 .SendAsync(request, cancellationToken)
                 .ConfigureAwait(false);
-
             var propertyBag = new PropertyBag(response.ToProperties());
             byte[] buffer = await ReadAsByteArrayAsync(response.Content, cancellationToken).ConfigureAwait(false);
             propertyBag.AddOrUpdateProperty(PropertyBagKeys.HttpContent, buffer);

--- a/src/XPing365.Sdk.Availability/Validators/HttpResponseHeadersValidator.cs
+++ b/src/XPing365.Sdk.Availability/Validators/HttpResponseHeadersValidator.cs
@@ -58,15 +58,15 @@ public class HttpResponseHeadersValidator(
             return Task.FromResult(CreateFailedTestStep(Errors.InsufficientData(handler: this)));
         }
 
-        HttpResponseHeaders responseHeaders = 
-            sendHttpRequestStep.PropertyBag.GetProperty<HttpResponseHeaders>(
-                PropertyBagKeys.HttpResponseHeaders);
-
         using var inst = new InstrumentationLog();
         TestStep testStep = null!;
 
         try
         {
+            HttpResponseHeaders responseHeaders =
+                sendHttpRequestStep.PropertyBag.GetProperty<HttpResponseHeaders>(
+                    PropertyBagKeys.HttpResponseHeaders);
+
             // Perform test step validation.
             bool isValid = _isValid(responseHeaders);
 

--- a/src/XPing365.Sdk.Availability/Validators/HttpStatusCodeValidator.cs
+++ b/src/XPing365.Sdk.Availability/Validators/HttpStatusCodeValidator.cs
@@ -57,14 +57,14 @@ public sealed class HttpStatusCodeValidator(
             return Task.FromResult(CreateFailedTestStep(Errors.InsufficientData(handler: this)));
         }
 
-        HttpStatusCode statusCode = 
-            httpRequestStep.PropertyBag.GetProperty<HttpStatusCode>(PropertyBagKeys.HttpStatus);
-
         using var inst = new InstrumentationLog();
         TestStep testStep = null!;
 
         try
         {
+            HttpStatusCode statusCode =
+                httpRequestStep.PropertyBag.GetProperty<HttpStatusCode>(PropertyBagKeys.HttpStatus);
+
             // Perform test step validation.
             bool isValid = _isValid(statusCode);
 

--- a/src/XPing365.Sdk.Availability/Validators/ServerContentResponseValidator.cs
+++ b/src/XPing365.Sdk.Availability/Validators/ServerContentResponseValidator.cs
@@ -1,0 +1,122 @@
+﻿using System.Net.Http.Headers;
+using XPing365.Sdk.Availability.TestSteps;
+using XPing365.Sdk.Core;
+using XPing365.Sdk.Shared;
+
+namespace XPing365.Sdk.Availability.Validators;
+
+/// <summary>
+/// The HttpStatusCodeValidator class is a concrete implementation of the <see cref="TestStepHandler"/> class that is 
+/// used to validate server content response. It takes a Func&lt;byte[], HttpContentHeaders, bool&gt; delegate as a
+/// parameter, which is used to validate the response content. The errorMessage parameter is an optional error message 
+/// that can be used to provide additional information about the validation failure.
+/// </summary>
+/// <remarks>
+/// Server response content is received as a byte array and stored as such. If needed, it can be converted to a string 
+/// using the encoding which is available in the <see cref="HttpContentHeaders.ContentEncoding" />.
+/// 
+/// When an HTTP response contains multiple content encodings, the <see cref="HttpContentHeaders.ContentEncoding" /> 
+/// property returns a collection of strings that represents the content encoding of the response content. The order of 
+/// the encodings in the collection indicates the order in which they were applied to the response content.
+/// 
+/// To determine the correct content encoding to use, you should start with the first encoding in the collection and 
+/// work your way down until you find an encoding that you can decode. If you are unable to decode any of the encodings, 
+/// you should return an error.
+/// </remarks>
+/// <example>
+/// <code>
+/// var serverContentValidator = new ServerContentResponseValidator(
+///     isValid: (byte[] buffer, HttpContentHeaders contentHeaders) =>
+///     {
+///         foreach (string encoding in contentHeaders.ContentEncoding)
+///         {
+///             try
+///             {
+///                 string contentString = Encoding.GetEncoding(encoding).GetString(buffer);
+///                 return contentString.Contains("title", StringComparison.InvariantCulture);
+///             }
+///             catch (Exception)
+///             {
+///                 // Unable to decode content with this encoding, try the next one
+///             }
+///         }
+/// 
+///         return false;
+///     },
+///     errorMessage: (byte[] buffer, HttpContentHeaders contentHeaders) => 
+///         $"The HTTP content response did not contain expected text.");
+/// var validator = new Validator(serverContentValidator);
+/// </code>
+/// </example>
+/// <param name="isValid">Func&lt;byte[], HttpContentHeaders, bool&gt; delegate used to validate the response 
+/// content.
+/// </param>
+/// <param name="errorMessage">Optional information about the validation failure.</param>
+public class ServerContentResponseValidator(
+    Func<byte[], HttpContentHeaders, bool> isValid,
+    Func<byte[], HttpContentHeaders, string>? errorMessage = null) : 
+        TestStepHandler(StepName, TestStepType.ValidateStep)
+{
+    public const string StepName = "Server content response validation";
+
+    private readonly Func<byte[], HttpContentHeaders, bool> _isValid = isValid;
+    private readonly Func<byte[], HttpContentHeaders, string>? _errorMessage = errorMessage;
+
+    /// <summary>
+    /// This method performs the test step operation asynchronously.
+    /// </summary>
+    /// <param name="url">A Uri object that represents the URL of the page being validated.</param>
+    /// <param name="settings">A <see cref="TestSettings"/> object that contains the settings for the test.</param>
+    /// <param name="session">A <see cref="TestSession"/> object that represents the test session.</param>
+    /// <param name="cancellationToken">An optional CancellationToken object that can be used to cancel this operation.
+    /// </param>
+    /// <returns><see cref="TestStep"/> object.</returns>
+    /// <exception cref="ArgumentNullException">If any of the following parameters: url, settings or session is null.
+    /// </exception>
+    public override Task<TestStep> HandleStepAsync(
+        Uri url,
+        TestSettings settings,
+        TestSession session,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(url, nameof(url));
+        ArgumentNullException.ThrowIfNull(settings, nameof(settings));
+        ArgumentNullException.ThrowIfNull(session, nameof(session));
+
+        TestStep? sendHttpRequestStep = session.Steps.FirstOrDefault(step => step.Name == SendHttpRequest.StepName);
+
+        if (sendHttpRequestStep == null)
+        {
+            return Task.FromResult(CreateFailedTestStep(Errors.InsufficientData(handler: this)));
+        }
+        
+        TestStep testStep = null!;
+        using var inst = new InstrumentationLog();
+        try
+        {
+            byte[] contentBuffer = 
+                sendHttpRequestStep.PropertyBag.GetProperty<byte[]>(PropertyBagKeys.HttpContent);
+            HttpContentHeaders contentHeaders =
+                sendHttpRequestStep.PropertyBag.GetProperty<HttpContentHeaders>(PropertyBagKeys.HttpContentHeaders);
+        
+            // Perform test step validation.
+            bool isValid = _isValid(contentBuffer, contentHeaders);
+
+            if (isValid)
+            {
+                testStep = CreateSuccessTestStep(inst.StartTime, inst.ElapsedTime, new PropertyBag());
+            }
+            else
+            {
+                string? errmsg = _errorMessage?.Invoke(contentBuffer, contentHeaders);
+                testStep = CreateFailedTestStep(errmsg ?? Errors.ValidationFailed(handler: this));
+            }
+        }
+        catch (Exception exception)
+        {
+            testStep = CreateTestStepFromException(exception, inst.StartTime, inst.ElapsedTime);
+        }
+
+        return Task.FromResult(testStep);
+    }
+}

--- a/src/XPing365.Sdk.Core/PropertyBagKeys.cs
+++ b/src/XPing365.Sdk.Core/PropertyBagKeys.cs
@@ -72,6 +72,11 @@ public static class PropertyBagKeys
     public readonly static PropertyBagKey HttpContent = new(nameof(HttpContent));
 
     /// <summary>
+    /// Represents the HTTP content headers.
+    /// </summary>
+    public readonly static PropertyBagKey HttpContentHeaders = new(nameof(HttpContentHeaders));
+
+    /// <summary>
     /// Represents the boolean value determining whether to retry failing HTTP request.
     /// </summary>
     public readonly static PropertyBagKey HttpRetry = new(nameof(HttpRetry));

--- a/src/XPing365.Sdk.Core/Validators/IValidator.cs
+++ b/src/XPing365.Sdk.Core/Validators/IValidator.cs
@@ -5,8 +5,8 @@
 /// validation must implement.
 /// </summary>
 /// <remarks>
-/// The IValidator interface is implemented by the <see cref="Validator"/> class, which is used to execute a collection 
-/// of <see cref="TestStepHandler"/> objects that are used to validate <see cref="TestSession"/> object.
+/// The IValidator interface is implemented by the <see cref="Validator"/> class, which is a helper class aggregating 
+/// collection of <see cref="TestStepHandler"/> objects that are used to validate <see cref="TestSession"/> instance.
 /// </remarks>
 public interface IValidator
 {

--- a/tests/XPing365.Sdk.IntegrationTests/TestFixtures/TestFixtureProvider.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/TestFixtures/TestFixtureProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Hosting;
-using XPing365.Sdk.Availability.Extensions;
+using XPing365.Sdk.Availability.DependencyInjection;
 
 namespace XPing365.Sdk.IntegrationTests.TestFixtures;
 

--- a/tests/XPing365.Sdk.IntegrationTests/XPing365.Sdk.IntegrationTests.csproj
+++ b/tests/XPing365.Sdk.IntegrationTests/XPing365.Sdk.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <NoWarn>1701;1702;CA1031;CA1716</NoWarn>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
This pull request adds a new class called `ServerResponseContentValidator` to the project. The purpose of this class is to validate the content of server responses. The class is a concrete implementation of the `TestStepHandler` and it takes a `Func<byte[], HttpContentHeaders, bool>` delegate as a parameter, which is used to validate the response content. The `errorMessage` parameter is an optional error message delegate that can be used to provide additional information about the validation failure.

**Changes Made:**
Added new class `ServerResponseContentValidator`.

**Testing:**
This change also includes integration test for the `ServerResponseContentValidator` class to ensure that it works as expected.