### PR TITLE
[Bugfix] Fix InMemoryHttpServer blocking GetContext() call.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Build
       run: dotnet build -c Release --no-restore
     - name: Test
-      run: dotnet test ./tests/XPing365.Sdk.UnitTests/XPing365.Sdk.UnitTests.csproj -c Release --no-build --verbosity normal 
+      run: dotnet test -c Release --no-build --verbosity normal 

--- a/src/XPing365.Sdk.Availability/TestSteps/IPAddressAccessibilityCheck.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/IPAddressAccessibilityCheck.cs
@@ -16,9 +16,6 @@ namespace XPing365.Sdk.Availability.TestSteps;
 /// </summary>
 public sealed class IPAddressAccessibilityCheck() : TestComponent(StepName, TestStepType.ActionStep)
 {
-    // A buffer of 32 bytes of data to be transmitted during test.
-    private readonly byte[] _buffer = Encoding.ASCII.GetBytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-
     public const string StepName = "IPAddress accessibility check";
 
     /// <summary>
@@ -62,7 +59,8 @@ public sealed class IPAddressAccessibilityCheck() : TestComponent(StepName, Test
                     PingReply reply = await pingSender.SendPingAsync(
                         address: address,
                         timeout: GetTimeout(settings),
-                        buffer: _buffer,
+                        // On Linux, non-privileged processes can't send a custom payload. Please leave this empty.
+                        buffer: [],
                         options: GetOptions(settings)).ConfigureAwait(false);
 
                     context.SessionBuilder.PropertyBag.AddOrUpdateProperties(reply.ToProperties());

--- a/tests/XPing365.Sdk.IntegrationTests/HttpServer/InMemoryHttpServer.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/HttpServer/InMemoryHttpServer.cs
@@ -5,27 +5,29 @@ namespace XPing365.Sdk.IntegrationTests.HttpServer;
 internal static class InMemoryHttpServer
 {
     public static Task TestServer(
-        Action<HttpListenerResponse> responseBuilder)
+        Action<HttpListenerResponse> responseBuilder,
+        CancellationToken cancellationToken = default)
     {
-        return TestServer(responseBuilder, requestReceived: (request) => { });
+        return TestServer(responseBuilder, requestReceived: (request) => { }, cancellationToken);
     }
 
     public static Task TestServer(
         Action<HttpListenerResponse> responseBuilder,
-        Action<HttpListenerRequest> requestReceived)
+        Action<HttpListenerRequest> requestReceived,
+        CancellationToken cancellationToken = default)
     {
-        return Task.Run(() =>
+        return Task.Run(async () =>
         {
             using HttpListener listener = new();
             listener.Prefixes.Add(GetTestServerAddress().AbsoluteUri);
             listener.Start();
             // GetContext method blocks while waiting for a request. 
-            HttpListenerContext context = listener.GetContext();
+            HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
             // Examine client request received
             requestReceived?.Invoke(context.Request);
             // Build HttpListenerResponse
             responseBuilder(context.Response);
-        });
+        }, cancellationToken);
     }
 
     public static Uri GetTestServerAddress()


### PR DESCRIPTION
This PR fixes a bug in the `InMemoryHttpServer` class that caused the `GetContext()` method to block indefinitely. The bug was only exposed on linux. 

**Changes made:**
Call to `GetContext()` got replaced with `GetContextAsync()`. 