### PR TITLE
Replace Common project with Shared project for internal types. 

### DIFF
--- a/src/XPing365.Sdk.Availability.Browser/TestSteps/HeadlessBrowserRequestSender.cs
+++ b/src/XPing365.Sdk.Availability.Browser/TestSteps/HeadlessBrowserRequestSender.cs
@@ -2,6 +2,7 @@
 using XPing365.Sdk.Availability.TestSteps.HeadlessBrowser;
 using XPing365.Sdk.Common;
 using XPing365.Sdk.Core;
+using XPing365.Sdk.Core.Common;
 using XPing365.Sdk.Core.Components;
 
 namespace XPing365.Sdk.Availability.TestSteps;

--- a/src/XPing365.Sdk.Availability.Browser/XPing365.Sdk.Availability.Browser.csproj
+++ b/src/XPing365.Sdk.Availability.Browser/XPing365.Sdk.Availability.Browser.csproj
@@ -13,8 +13,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\XPing365.Sdk.Availability\XPing365.Sdk.Availability.csproj" />
-    <ProjectReference Include="..\XPing365.Sdk.Common\XPing365.Sdk.Common.csproj" />
     <ProjectReference Include="..\XPing365.Sdk.Core\XPing365.Sdk.Core.csproj" />
   </ItemGroup>
+
+  <Import Project="..\XPing365.Sdk.Shared\XPing365.Sdk.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/src/XPing365.Sdk.Availability/TestSteps/SendHttpRequest.cs
+++ b/src/XPing365.Sdk.Availability/TestSteps/SendHttpRequest.cs
@@ -2,6 +2,7 @@
 using XPing365.Sdk.Core;
 using XPing365.Sdk.Common;
 using XPing365.Sdk.Core.Components;
+using XPing365.Sdk.Core.Common;
 
 namespace XPing365.Sdk.Availability.TestSteps;
 

--- a/src/XPing365.Sdk.Availability/XPing365.Sdk.Availability.csproj
+++ b/src/XPing365.Sdk.Availability/XPing365.Sdk.Availability.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\XPing365.Sdk.Common\XPing365.Sdk.Common.csproj" />
     <ProjectReference Include="..\XPing365.Sdk.Core\XPing365.Sdk.Core.csproj" />
   </ItemGroup>
 
@@ -20,5 +19,7 @@
     <InternalsVisibleTo Include="XPing365.Sdk.IntegrationTests" />
     <InternalsVisibleTo Include="XPing365.Sdk.UnitTests" />
   </ItemGroup>
+
+  <Import Project="..\XPing365.Sdk.Shared\XPing365.Sdk.Shared.projitems" Label="Shared" />
   
 </Project>

--- a/src/XPing365.Sdk.Common/XPing365.Sdk.Common.csproj
+++ b/src/XPing365.Sdk.Common/XPing365.Sdk.Common.csproj
@@ -1,9 +1,0 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-</Project>

--- a/src/XPing365.Sdk.Core/Common/InstrumentationLog.cs
+++ b/src/XPing365.Sdk.Core/Common/InstrumentationLog.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
+using XPing365.Sdk.Common;
 
-namespace XPing365.Sdk.Common;
+namespace XPing365.Sdk.Core.Common;
 
 /// <summary>
 /// This class provides a set utilities that can be used to log data related to code execution time.

--- a/src/XPing365.Sdk.Core/Components/Session/TestSessionBuilder.cs
+++ b/src/XPing365.Sdk.Core/Components/Session/TestSessionBuilder.cs
@@ -1,5 +1,4 @@
-﻿using XPing365.Sdk.Common;
-using XPing365.Sdk.Core.Common;
+﻿using XPing365.Sdk.Core.Common;
 
 namespace XPing365.Sdk.Core.Components.Session;
 

--- a/src/XPing365.Sdk.Core/XPing365.Sdk.Core.csproj
+++ b/src/XPing365.Sdk.Core/XPing365.Sdk.Core.csproj
@@ -12,7 +12,5 @@
     <InternalsVisibleTo Include="XPing365.Sdk.UnitTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\XPing365.Sdk.Common\XPing365.Sdk.Common.csproj" />
-  </ItemGroup>
+  <Import Project="..\XPing365.Sdk.Shared\XPing365.Sdk.Shared.projitems" Label="Shared" />
 </Project>

--- a/src/XPing365.Sdk.Shared/ArgumentValidation.cs
+++ b/src/XPing365.Sdk.Shared/ArgumentValidation.cs
@@ -7,7 +7,7 @@ namespace XPing365.Sdk.Common;
 /// <summary>
 /// This class provide extension methods to help verify parameters validity.
 /// </summary>
-public static class ArgumentValidation
+internal static class ArgumentValidation
 {
     /// <summary>
     /// Basic Validation helper to verify parameter null validity.

--- a/src/XPing365.Sdk.Shared/XPing365.Sdk.Shared.projitems
+++ b/src/XPing365.Sdk.Shared/XPing365.Sdk.Shared.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>18af9728-0693-431b-bb78-0577f98fe560</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>XPing365.Sdk.Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)ArgumentValidation.cs" />
+  </ItemGroup>
+</Project>

--- a/src/XPing365.Sdk.Shared/XPing365.Sdk.Shared.shproj
+++ b/src/XPing365.Sdk.Shared/XPing365.Sdk.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>18af9728-0693-431b-bb78-0577f98fe560</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="XPing365.Sdk.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/tests/XPing365.Sdk.UnitTests/Common/InstrumentationLogTests.cs
+++ b/tests/XPing365.Sdk.UnitTests/Common/InstrumentationLogTests.cs
@@ -1,4 +1,6 @@
-﻿namespace XPing365.Sdk.Common.UnitTests;
+﻿using XPing365.Sdk.Core.Common;
+
+namespace XPing365.Sdk.Common.UnitTests;
 
 public sealed class InstrumentationLogTests
 {

--- a/tests/XPing365.Sdk.UnitTests/XPing365.Sdk.UnitTests.csproj
+++ b/tests/XPing365.Sdk.UnitTests/XPing365.Sdk.UnitTests.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Common\ArgumentValidationTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
@@ -25,7 +29,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\XPing365.Sdk.Availability\XPing365.Sdk.Availability.csproj" />
-    <ProjectReference Include="..\..\src\XPing365.Sdk.Common\XPing365.Sdk.Common.csproj" />
     <ProjectReference Include="..\..\src\XPing365.Sdk.Core\XPing365.Sdk.Core.csproj" />
   </ItemGroup>
 

--- a/xping365-sdk.sln
+++ b/xping365-sdk.sln
@@ -25,9 +25,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{B131
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp", "samples\ConsoleApp\ConsoleApp.csproj", "{29F6A072-EA33-408E-96B0-44934852C7C3}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPing365.Sdk.Common", "src\XPing365.Sdk.Common\XPing365.Sdk.Common.csproj", "{2A479683-3119-4645-A6B7-7B91CA550932}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPing365.Sdk.Availability.Browser", "src\XPing365.Sdk.Availability.Browser\XPing365.Sdk.Availability.Browser.csproj", "{777DCEDB-580F-477D-B2D7-0B7DD299ED5B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XPing365.Sdk.Availability.Browser", "src\XPing365.Sdk.Availability.Browser\XPing365.Sdk.Availability.Browser.csproj", "{777DCEDB-580F-477D-B2D7-0B7DD299ED5B}"
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "XPing365.Sdk.Shared", "src\XPing365.Sdk.Shared\XPing365.Sdk.Shared.shproj", "{18AF9728-0693-431B-BB78-0577F98FE560}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -55,10 +55,6 @@ Global
 		{29F6A072-EA33-408E-96B0-44934852C7C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29F6A072-EA33-408E-96B0-44934852C7C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{29F6A072-EA33-408E-96B0-44934852C7C3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2A479683-3119-4645-A6B7-7B91CA550932}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2A479683-3119-4645-A6B7-7B91CA550932}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2A479683-3119-4645-A6B7-7B91CA550932}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2A479683-3119-4645-A6B7-7B91CA550932}.Release|Any CPU.Build.0 = Release|Any CPU
 		{777DCEDB-580F-477D-B2D7-0B7DD299ED5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{777DCEDB-580F-477D-B2D7-0B7DD299ED5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{777DCEDB-580F-477D-B2D7-0B7DD299ED5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -73,10 +69,16 @@ Global
 		{6814CE18-75C3-4B0A-864A-13113F732FCA} = {E0C3A702-A0A5-4D65-9CBE-B017E76DDC6F}
 		{CF9C97AA-FA29-43CD-B45F-76E60A6B1D9A} = {464CE18C-1C75-473C-812A-E958172BC048}
 		{29F6A072-EA33-408E-96B0-44934852C7C3} = {B1313130-03E1-4238-BB93-74BD2E0084C1}
-		{2A479683-3119-4645-A6B7-7B91CA550932} = {464CE18C-1C75-473C-812A-E958172BC048}
 		{777DCEDB-580F-477D-B2D7-0B7DD299ED5B} = {464CE18C-1C75-473C-812A-E958172BC048}
+		{18AF9728-0693-431B-BB78-0577F98FE560} = {464CE18C-1C75-473C-812A-E958172BC048}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1EAD876E-2071-435E-AEC4-D3DEF2F4A328}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\XPing365.Sdk.Shared\XPing365.Sdk.Shared.projitems*{18af9728-0693-431b-bb78-0577f98fe560}*SharedItemsImports = 13
+		src\XPing365.Sdk.Shared\XPing365.Sdk.Shared.projitems*{777dcedb-580f-477d-b2d7-0b7dd299ed5b}*SharedItemsImports = 5
+		src\XPing365.Sdk.Shared\XPing365.Sdk.Shared.projitems*{cf9c97aa-fa29-43cd-b45f-76e60a6b1d9a}*SharedItemsImports = 5
+		src\XPing365.Sdk.Shared\XPing365.Sdk.Shared.projitems*{ec960cdd-7ea0-4a2e-ba66-da05d361014e}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR replaces the Common project with the Shared project type for internal types. The Common project was exposing public types that were only used internally by other projects. The Shared project only exports internal types as needed by other projects.


The main reason for this change is to simplify the importing of Shared items and the embedding of NuGet packages. By using the Shared project, we can avoid having to reference the Common project or embed its binaries in the NuGet packages. This reduces the size of the packages and the risk of version conflicts.