### PR TITLE
Make AvailabilityTestAgent more descriptive by calling it HttpClientTestAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,19 +74,19 @@ using XPing365.Availability.DependencyInjection;
 Host.CreateDefaultBuilder()
     .ConfigureServices(services =>
     {
-        services.AddAvailabilityTestAgent();
+        services.AddHttpClientTestAgent();
     });
 ```
 
 ```c#
 using XPing365.Availability
 
-var testAgent = _serviceProvider.GetRequiredService<AvailabilityTestAgent>();
+var testAgent = _serviceProvider.GetRequiredService<HttpClientTestAgent>();
 
 TestSession session = await testAgent
     .RunAsync(
         new Uri("www.demoblaze.com"),
-        TestSettings.DefaultForAvailability)
+        TestSettings.DefaultForHttpClient)
     .ConfigureAwait(false);
 ```
 

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -23,19 +23,19 @@ using XPing365.Availability.DependencyInjection;
 Host.CreateDefaultBuilder()
     .ConfigureServices(services =>
     {
-        services.AddAvailabilityTestAgent();
+        services.AddHttpClientTestAgent();
     });
 ```
 
 ```c#
 using XPing365.Availability
 
-var testAgent = _serviceProvider.GetRequiredService<AvailabilityTestAgent>();
+var testAgent = _serviceProvider.GetRequiredService<HttpClientTestAgent>();
 
 TestSession session = await testAgent
     .RunAsync(
         new Uri("www.demoblaze.com"),
-        TestSettings.DefaultForAvailability)
+        TestSettings.DefaultForHttpClient)
     .ConfigureAwait(false);
 ```
 

--- a/docs/wiki/tutorial.md
+++ b/docs/wiki/tutorial.md
@@ -65,10 +65,10 @@ class Program
         command.SetHandler(async (InvocationContext context) =>
         {
             Uri url = context.ParseResult.GetValueForOption(urlOption)!;
-            var testAgent = host.Services.GetRequiredService<AvailabilityTestAgent>();
+            var testAgent = host.Services.GetRequiredService<HttpClientTestAgent>();
 
             TestSession session = await testAgent
-                .RunAsync(url, settings: TestSettings.DefaultForAvailability);
+                .RunAsync(url, settings: TestSettings.DefaultForHttpClient);
             context.Console.WriteLine("\nSummary:");
             context.Console.WriteLine($"{session}");
             context.ExitCode = session.IsValid ? EXIT_SUCCESS : EXIT_FAILURE;
@@ -82,7 +82,7 @@ class Program
             .ConfigureServices((services) =>
             {
                 services.AddTransient<IProgress<TestStep>, Progress>();
-                services.AddAvailabilityTestAgent();
+                services.AddHttpClientTestAgent();
             })
             .ConfigureLogging(logging =>
             {
@@ -115,7 +115,7 @@ class Progress(ILogger<Program> logger) : IProgress<TestStep>
 }
 ```
 
-The `IProgress<TestStep>` interface is implemented by this class, which is called on every test step performed by `AvailabilityTestAgent` during its testing operation. This allows to monitor the progress of the test execution.
+The `IProgress<TestStep>` interface is implemented by this class, which is called on every test step performed by `HttpClientTestAgent` during its testing operation. This allows to monitor the progress of the test execution.
 
 The preceding code we added earlier does following:
 
@@ -127,7 +127,7 @@ static IHostBuilder CreateHostBuilder(string[] args) =>
         .ConfigureServices((services) =>
         {
             services.AddTransient<IProgress<TestStep>, Progress>();
-            services.AddAvailabilityTestAgent();
+            services.AddHttpClientTestAgent();
         })
         .ConfigureLogging(logging =>
         {
@@ -162,7 +162,7 @@ command.SetHandler(async (InvocationContext context) =>
 return await command.InvokeAsync(args);
 ```
 
-- Handler method retrieves `AvailabilityTestAgent` service and runs availability test operations with default test settings against the `url` value: 
+- Handler method retrieves `HttpClientTestAgent` service and runs availability test operations with default test settings against the `url` value: 
 
 ```csharp
 
@@ -170,10 +170,10 @@ command.SetHandler(async (InvocationContext context) =>
 {
     (...)
 
-    var testAgent = host.Services.GetRequiredService<AvailabilityTestAgent>();
+    var testAgent = host.Services.GetRequiredService<HttpClientTestAgent>();
 
     TestSession session = await testAgent
-        .RunAsync(url, settings: TestSettings.DefaultForAvailability);
+        .RunAsync(url, settings: TestSettings.DefaultForHttpClient);
 });
 
 return await command.InvokeAsync(args);
@@ -271,7 +271,7 @@ new ServerContentResponseValidator(
         $"The HTTP response content exceeded the maximum allowed size of {MAX_SIZE_IN_BYTES} bytes.")
 ```
 
-- In the command handler reference the newly added `Pipeline` in the `AvailabilityTestAgent` as follows:
+- In the command handler reference the newly added `Pipeline` in the `HttpClientTestAgent` as follows:
 
 ```csharp
 testAgent.Container.AddComponent(CreateValidationPipeline());
@@ -279,7 +279,7 @@ testAgent.Container.AddComponent(CreateValidationPipeline());
 
 ## Test the new app with validation pipeline
 
-Now if you try to run the app, you get additional test steps performed by the `AvailabilityTestAgent` in the order in which they were added:
+Now if you try to run the app, you get additional test steps performed by the `HttpClientTestAgent` in the order in which they were added:
 
 ```console
 ConsoleApp.exe --url http://demoblaze.com

--- a/nuspec/README.md
+++ b/nuspec/README.md
@@ -31,19 +31,19 @@ using XPing365.Availability.DependencyInjection;
 Host.CreateDefaultBuilder()
     .ConfigureServices(services =>
     {
-        services.AddAvailabilityTestAgent();
+        services.AddHttpClientTestAgent();
     });
 ```
 
 ```c#
 using XPing365.Availability
 
-var testAgent = _serviceProvider.GetRequiredService<AvailabilityTestAgent>();
+var testAgent = _serviceProvider.GetRequiredService<HttpClientTestAgent>();
 
 TestSession session = await testAgent
     .RunAsync(
         new Uri("www.demoblaze.com"),
-        TestSettings.DefaultForAvailability)
+        TestSettings.DefaultForHttpClient)
     .ConfigureAwait(false);
 ```
 

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -35,11 +35,11 @@ sealed class Program
         command.SetHandler(async (InvocationContext context) =>
         {
             Uri url = context.ParseResult.GetValueForOption(urlOption)!;
-            var testAgent = host.Services.GetRequiredService<AvailabilityTestAgent>();
+            var testAgent = host.Services.GetRequiredService<HttpClientTestAgent>();
             testAgent.Container.AddComponent(CreateValidationPipeline());
 
             TestSession session = await testAgent
-                .RunAsync(url, settings: TestSettings.DefaultForAvailability);
+                .RunAsync(url, settings: TestSettings.DefaultForHttpClient);
             context.Console.WriteLine("\nSummary:");
             context.Console.WriteLine($"{session}");
             context.ExitCode = session.IsValid ? EXIT_SUCCESS : EXIT_FAILURE;
@@ -53,7 +53,7 @@ sealed class Program
             .ConfigureServices((services) =>
             {
                 services.AddTransient<IProgress<TestStep>, Progress>();
-                services.AddAvailabilityTestAgent();
+                services.AddHttpClientTestAgent();
             })
             .ConfigureLogging(logging =>
             {

--- a/src/XPing365.Sdk.Availability.Browser/TestSteps/HeadlessBrowser/BrowserContext.cs
+++ b/src/XPing365.Sdk.Availability.Browser/TestSteps/HeadlessBrowser/BrowserContext.cs
@@ -30,4 +30,10 @@ public class BrowserContext
     /// The default value is null, which means the default user agent of the browser type will be used.
     /// </summary>
     public string? UserAgent { get; set; }
+
+    /// <summary>
+    /// Emulates consistent viewport for each page. Defaults to an 1280x720 viewport.
+    /// Learn more about <a href="https://playwright.dev/dotnet/docs/emulation#viewport">viewport emulation</a>.
+    /// </summary>
+    public ViewportSize? ViewportSize { get; set; }
 }

--- a/src/XPing365.Sdk.Availability.Browser/TestSteps/HeadlessBrowser/HeadlessBrowserClient.cs
+++ b/src/XPing365.Sdk.Availability.Browser/TestSteps/HeadlessBrowser/HeadlessBrowserClient.cs
@@ -55,7 +55,8 @@ public class HeadlessBrowserClient(IBrowser browser, BrowserContext context) : I
 
         var options = new BrowserNewPageOptions
         {
-            UserAgent = Context.UserAgent
+            UserAgent = Context.UserAgent, 
+            ViewportSize = Context.ViewportSize
         };
 
         var page = await _browser.NewPageAsync(options).ConfigureAwait(false);

--- a/src/XPing365.Sdk.Availability.Browser/TestSteps/HeadlessBrowserRequestSender.cs
+++ b/src/XPing365.Sdk.Availability.Browser/TestSteps/HeadlessBrowserRequestSender.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Net.Http.Headers;
+using Microsoft.Playwright;
 using XPing365.Sdk.Availability.TestSteps.HeadlessBrowser;
 using XPing365.Sdk.Common;
 using XPing365.Sdk.Core;
@@ -85,7 +86,13 @@ public sealed class HeadlessBrowserRequestSender(IHeadlessBrowserFactory headles
         return new BrowserContext
         {
             Timeout = settings.PropertyBag.GetProperty<TimeSpan>(PropertyBagKeys.HttpRequestTimeout),
-            UserAgent = values?.FirstOrDefault()
+            UserAgent = values?.FirstOrDefault(),
+            Type = settings.BrowserType,
+            ViewportSize = settings.BrowserViewportSize != null ? new ViewportSize
+            {
+                Height = settings.BrowserViewportSize.Value.Height,
+                Width = settings.BrowserViewportSize.Value.Width
+            } : null
         };
     }
 

--- a/src/XPing365.Sdk.Availability/DependencyInjection/DependencyInjectionExtension.cs
+++ b/src/XPing365.Sdk.Availability/DependencyInjection/DependencyInjectionExtension.cs
@@ -9,13 +9,13 @@ namespace XPing365.Sdk.Availability.DependencyInjection;
 public static class DependencyInjectionExtension
 {
     /// <summary>
-    /// This extension method adds the AvailabilityTestAgent service and related services to your application’s service 
+    /// This extension method adds the HttpClientTestAgent service and related services to your application’s service 
     /// collection and configures a named <see cref="HttpClient"/> clients.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/>.</param>
     /// <param name="configuration">The <see cref="HttpClientConfiguration"/>.</param>
     /// <returns><see cref="IServiceCollection"/> object.</returns>
-    public static IServiceCollection AddAvailabilityTestAgent(
+    public static IServiceCollection AddHttpClientTestAgent(
         this IServiceCollection services,
         Action<IServiceProvider, HttpClientConfiguration>? configuration = null)
     {
@@ -77,7 +77,7 @@ public static class DependencyInjectionExtension
                     durationOfBreak: httpClientConfiguration.DurationOfBreak));
 
         services.AddTransient<ITestSessionBuilder, TestSessionBuilder>();
-        services.AddTransient<AvailabilityTestAgent>();
+        services.AddTransient<HttpClientTestAgent>();
 
         return services;
     }

--- a/src/XPing365.Sdk.Availability/HttpClientTestAgent.cs
+++ b/src/XPing365.Sdk.Availability/HttpClientTestAgent.cs
@@ -6,7 +6,7 @@ using XPing365.Sdk.Core.Components.Session;
 namespace XPing365.Sdk.Availability;
 
 /// <summary>
-/// The AvailabilityTestAgent class is a concrete implementation of the <see cref="TestAgent"/> class that is used to 
+/// The HttpClientTestAgent class is a concrete implementation of the <see cref="TestAgent"/> class that is used to 
 /// perform availability tests. This class consist of following action test steps: 
 /// <see cref="DnsLookup"/>, <see cref="IPAddressAccessibilityCheck"/> and <see cref="SendHttpRequest"/> to perform the 
 /// availability tests. All action steps are performed in a specific order, and their results are added as 
@@ -20,21 +20,21 @@ namespace XPing365.Sdk.Availability;
 /// Host.CreateDefaultBuilder()
 ///     .ConfigureServices(services =>
 ///     {
-///         services.AddAvailabilityTestAgent();
+///         services.AddHttpClientTestAgent();
 ///     });
 /// 
-/// var testAgent = _serviceProvider.GetRequiredService&lt;AvailabilityTestAgent&gt;();
+/// var testAgent = _serviceProvider.GetRequiredService&lt;HttpClientTestAgent&gt;();
 /// 
 /// TestContext session = await testAgent
 ///     .RunAsync(
 ///         new Uri("www.demoblaze.com"),
-///         TestSettings.DefaultForAvailability)
+///         TestSettings.DefaultForHttpClient)
 ///     .ConfigureAwait(false);
 /// </code>
 /// </example>
 /// <param name="httpClientFactory"><see cref="IHttpClientFactory"/> implementation instance.</param>
 /// <param name="serviceProvider">An instance object of a mechanism for retrieving a service object.</param>
-public sealed class AvailabilityTestAgent(IHttpClientFactory httpClientFactory, IServiceProvider serviceProvider) : 
+public sealed class HttpClientTestAgent(IHttpClientFactory httpClientFactory, IServiceProvider serviceProvider) : 
     TestAgent(serviceProvider, new Pipeline(name: PipelineName, [
         new DnsLookup(), 
         new IPAddressAccessibilityCheck(), 

--- a/src/XPing365.Sdk.Core/Components/TestSettings.cs
+++ b/src/XPing365.Sdk.Core/Components/TestSettings.cs
@@ -22,13 +22,13 @@ public sealed class TestSettings
 
     /// <summary>
     /// Gets or sets a boolean value which determines whether to retry HTTP requests when they fail. Default is true, 
-    /// unless specified differently in <see cref="DefaultForAvailability"/>.
+    /// unless specified differently in <see cref="DefaultForHttpClient"/>.
     /// </summary>
     public bool RetryHttpRequestWhenFailed { get; set; } = true;
 
     /// <summary>
     /// Gets or sets a boolean value which determines whether to follow HTTP redirection responses. Default is true, 
-    /// unless specified differently in <see cref="DefaultForAvailability"/>.
+    /// unless specified differently in <see cref="DefaultForHttpClient"/>.
     /// </summary>
     public bool FollowHttpRedirectionResponses { get; set; } = true;
 
@@ -45,9 +45,26 @@ public sealed class TestSettings
     /// <summary>
     /// Gets or sets a value used to specify the size of the browser viewport for the web tests. It is a Size structure 
     /// that contains the width and height values in pixels. The default value is null, which means the browser will use 
-    /// the maximum available size.
+    /// its default available viewport.
     /// </summary>
-    public Size? BrowserViewPort { get; set; }
+    public Size? BrowserViewportSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value which specifies the browser type to use for the web tests. It can be one of the values from 
+    /// the BrowserType enum in the Playwright library, such as “chromium”, “firefox”, or “webkit”. The default value 
+    /// is “chromium”.
+    /// </summary>
+    /// <remarks>
+    /// The BrowserType property is used by the HeadlessBrowserTestAgent class to create a new browser instance of the 
+    /// specified type. For example, you can set this property as follows
+    /// <code>
+    /// var settings = new TestSettings
+    /// {
+    ///     BrowserType = BrowserType.Firefox;
+    /// }
+    /// </code>
+    /// </remarks>
+    public string BrowserType { get; set; } = "chromium";
 
     /// <summary>
     /// Gets a TestSettings object with default settings for http client testing.
@@ -55,7 +72,7 @@ public sealed class TestSettings
     /// See <see cref="PropertyBagKeys.PingDontFragmetOption"/> and <see cref="PropertyBagKeys.PingTTLOption"/> for more 
     /// information. It also has Http request timeout set to <see cref="DefaultHttpRequestTimeoutInSeconds"/> value.
     /// </summary>
-    public static TestSettings DefaultForAvailability
+    public static TestSettings DefaultForHttpClient
     {
         get
         {

--- a/tests/XPing365.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
@@ -103,7 +103,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
             response.Close(); // By closing a response it can be send to client.
         }
 
-        TestSettings testSettings = TestSettings.DefaultForAvailability;
+        TestSettings testSettings = TestSettings.DefaultForHttpClient;
         testSettings.RetryHttpRequestWhenFailed = false;
         testSettings.FollowHttpRedirectionResponses = false;
 
@@ -128,7 +128,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
         const string expectedErrMsg = 
             "Error 1000: Message: The request was canceled due to the configured HttpClient.Timeout of 1 seconds " +
             "elapsing.";
-        TestSettings settings = TestSettings.DefaultForAvailability;
+        TestSettings settings = TestSettings.DefaultForHttpClient;
         settings.PropertyBag.AddOrUpdateProperty(PropertyBagKeys.HttpRequestTimeout, TimeSpan.FromSeconds(1));
 
         void ResponseBuilder(HttpListenerResponse response)
@@ -157,7 +157,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
         // Arrange
         const string userAgent = "Chrome/51.0.2704.64 Safari/537.36";
 
-        TestSettings settings = TestSettings.DefaultForAvailability;
+        TestSettings settings = TestSettings.DefaultForHttpClient;
         var httpRequestHeaders = new Dictionary<string, IEnumerable<string>>
         {
             { HeaderNames.UserAgent, [userAgent] }
@@ -261,7 +261,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
             requestReceived ?? RequestReceived, 
             cts.Token);
         
-        var testAgent = _serviceProvider.GetRequiredService<AvailabilityTestAgent>();
+        var testAgent = _serviceProvider.GetRequiredService<HttpClientTestAgent>();
 
         if (component != null)
         {
@@ -271,7 +271,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
         TestSession session = await testAgent
             .RunAsync(
                 url: InMemoryHttpServer.GetTestServerAddress(),
-                settings: settings ?? TestSettings.DefaultForAvailability, 
+                settings: settings ?? TestSettings.DefaultForHttpClient, 
                 cancellationToken: cts.Token)
             .ConfigureAwait(false);
 

--- a/tests/XPing365.Sdk.IntegrationTests/BrowserTestAgentTests.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/BrowserTestAgentTests.cs
@@ -125,7 +125,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
         // Arrange
         const string userAgent = "Chrome/51.0.2704.64 Safari/537.36";
 
-        TestSettings settings = TestSettings.DefaultForAvailability;
+        TestSettings settings = TestSettings.DefaultForHttpClient;
         var httpRequestHeaders = new Dictionary<string, IEnumerable<string>>
         {
             { HeaderNames.UserAgent, [userAgent] }
@@ -155,7 +155,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
             "Error 1000: Message: Timeout 1000ms exceeded.\nCall log:\n  - navigating to \"http://localhost:8080/\", " +
             "waiting until \"load\"";
 
-        TestSettings settings = TestSettings.DefaultForAvailability;
+        TestSettings settings = TestSettings.DefaultForHttpClient;
         settings.PropertyBag.AddOrUpdateProperty(PropertyBagKeys.HttpRequestTimeout, TimeSpan.FromSeconds(1));
 
         void ResponseBuilder(HttpListenerResponse response)
@@ -252,7 +252,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
         TestSession session = await testAgent
             .RunAsync(
                 url: InMemoryHttpServer.GetTestServerAddress(),
-                settings: settings ?? TestSettings.DefaultForAvailability,
+                settings: settings ?? TestSettings.DefaultForHttpClient,
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 

--- a/tests/XPing365.Sdk.IntegrationTests/TestFixtures/TestFixtureProvider.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/TestFixtures/TestFixtureProvider.cs
@@ -21,7 +21,7 @@ public static class TestFixtureProvider
         builder.ConfigureServices(services =>
         {
             services.AddSingleton(implementationInstance: Mock.Of<IProgress<TestStep>>());
-            services.AddAvailabilityTestAgent();
+            services.AddHttpClientTestAgent();
             services.AddBrowserTestAgent();
         });
 

--- a/tests/XPing365.Sdk.UnitTests/Core/TestAgentTests.cs
+++ b/tests/XPing365.Sdk.UnitTests/Core/TestAgentTests.cs
@@ -49,7 +49,7 @@ public sealed class TestAgentTests(IServiceProvider serviceProvider)
         // Assert
         Assert.ThrowsAsync<ArgumentNullException>(async () => await testAgent.RunAsync(
             url: null!,
-            TestSettings.DefaultForAvailability).ConfigureAwait(false));
+            TestSettings.DefaultForHttpClient).ConfigureAwait(false));
     }
 
     [Test]

--- a/tests/XPing365.Sdk.UnitTests/TestFixtures/TestFixtureProvider.cs
+++ b/tests/XPing365.Sdk.UnitTests/TestFixtures/TestFixtureProvider.cs
@@ -21,7 +21,7 @@ public static class TestFixtureProvider
         builder.ConfigureServices(services =>
         {
             services.AddSingleton(implementationInstance: Mock.Of<IProgress<TestStep>>());
-            services.AddAvailabilityTestAgent();
+            services.AddHttpClientTestAgent();
         });
 
         var host = builder.Build();


### PR DESCRIPTION
This PR renames the `AvailabilityTestAgent` class to `HttpClientTestAgent`, to better reflect its functionality and purpose. The `AvailabilityTestAgent` class was a subclass of the `TestAgentBase` abstract class that implemented the `ITestAgent` interface. It was used to send HTTP requests to a web application using the `HttpClient` class, and to verify the availability and content of the server response. However, the name `AvailabilityTestAgent` was too vague and did not indicate the use of `HttpClient` or the scope of the test agent.

The new name `HttpClientTestAgent` is more descriptive and consistent with the naming convention of other test agents in the XPing365 SDK, such as `HeadlessBrowserTestAgent`. It clearly indicates that the test agent uses `HttpClient` to send HTTP requests, and that it can perform various tests on the web application, not just availability tests. This change improves the readability and maintainability of the code, and avoids confusion with other classes or concepts.

This PR also updates all the references and usages of the `AvailabilityTestAgent` class to use the new name `HttpClientTestAgent`. It does not change the functionality or behavior of the test agent, only the name. All the tests and documentation are also updated accordingly.