### PR TITLE
#21 Refactor Http Request System, update docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Host.CreateDefaultBuilder()
                     components: [
                         new DnsLookup(),
                         new IPAddressAccessibilityCheck(),
-                        new HttpClientRequestSender()
+                        new HttpRequestSender()
                     ]);
                 return agent;
             });

--- a/nuspec/README.md
+++ b/nuspec/README.md
@@ -40,7 +40,7 @@ Host.CreateDefaultBuilder()
                     components: [
                         new DnsLookup(),
                         new IPAddressAccessibilityCheck(),
-                        new HttpClientRequestSender()
+                        new HttpRequestSender()
                     ]);
                 return agent;
             });

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -55,18 +55,26 @@ public sealed class Program
         Host.CreateDefaultBuilder(args)
             .ConfigureServices((services) =>
             {
-                services.AddTransient<IProgress<TestStep>, Progress>();
+                // Register the Progress class as a singleton service
+                services.AddSingleton<IProgress<TestStep>, Progress>();
+                // Add HttpClients using the IHttpClientFactory
                 services.AddHttpClients();
+                // Adds a TestAgent service to the service collection and configures its pipeline
                 services.AddTestAgent(
                     name: "TestAgent", builder: (TestAgent agent) =>
                     {
+                        // Set the container of the TestAgent to a new Pipeline object
                         agent.Container = new Pipeline(
                             name: "Availability pipeline",
                             components: [
+                                // Add a DnsLookup component to the pipeline
                                 new DnsLookup(),
+                                // Add an IPAddressAccessibilityCheck component to the pipeline
                                 new IPAddressAccessibilityCheck(),
-                                new HttpClientRequestSender()
+                                // Add an HttpRequestSender component to the pipeline
+                                new HttpRequestSender()
                             ]);
+                        // Return the configured TestAgent object
                         return agent;
                     });
             })

--- a/src/XPing365.Sdk.Availability/TestActions/HttpRequestSender.cs
+++ b/src/XPing365.Sdk.Availability/TestActions/HttpRequestSender.cs
@@ -1,0 +1,74 @@
+﻿using XPing365.Sdk.Availability.TestActions.Internals;
+using XPing365.Sdk.Core;
+using XPing365.Sdk.Core.Common;
+using XPing365.Sdk.Core.Components;
+using XPing365.Sdk.Core.Session;
+
+namespace XPing365.Sdk.Availability.TestActions;
+
+/// <summary>
+/// The HttpRequestSender class is a unified interface for sending HTTP requests using either HttpClient or Headless 
+/// browser. Users can specify the desired client type in the constructor parameter. If no client type is provided, the 
+/// HttpRequestSender class will use HttpClient by default.
+/// </summary>
+/// <remarks>
+/// <para>
+/// HttpClient is a .NET class that provides a high-level abstraction for sending and receiving HTTP requests and 
+/// responses. It is fast, lightweight, and easy to use. However, it does not process HTML responses or run JavaScript 
+/// code, which may limit its ability to validate server responses. Headless Browsers are browsers that run without a 
+/// graphical user interface, but can still render web pages and execute JavaScript code. They are useful for simulating 
+/// user interactions and testing dynamic web applications. However, they are slower, heavier, and more complex than 
+/// HttpClient. 
+/// </para>
+/// <para>
+/// Depending on your testing needs, you can choose either or both of these mechanisms to create and run your HTTP 
+/// requests with XPing365 SDK.
+/// </para>
+/// <note type="tip">
+/// The HttpRequestSender class does not support using both HttpClient and Headless browser in the same testing 
+/// pipeline. If you try to do so, the test session results from one client will be overwritten by the results from the 
+/// other client, and you will lose some data. If you need to test the same URL with both clients, you should create two 
+/// separate testing pipelines, one for each client type, and run them independently.
+/// </note>
+/// </remarks>
+public class HttpRequestSender(Client client = Client.HttpClient) : 
+    TestComponent(name: StepName, type: TestStepType.ActionStep)
+{
+    private readonly Lazy<HttpClientRequestSender> _httpClientRequestSender = new(
+        valueFactory: () => new HttpClientRequestSender($"{StepName} ({nameof(Client.HttpClient)})"), 
+        isThreadSafe: true);
+    private readonly Lazy<HeadlessBrowserRequestSender> _headlessBrowserRequestSender = new(
+        valueFactory: () => new HeadlessBrowserRequestSender($"{StepName} ({nameof(Client.HeadlessBrowser)})"), 
+        isThreadSafe: true);
+    
+    private readonly Client _client = client;
+
+    public const string StepName = "Http request sender";
+
+    /// <summary>
+    /// This method performs the test step operation asynchronously.
+    /// </summary>
+    /// <param name="url">A Uri object that represents the URL of the page being validated.</param>
+    /// <param name="settings">A <see cref="TestSettings"/> object that contains the settings for the test.</param>
+    /// <param name="context">A <see cref="TestContext"/> object that represents the test session.</param>
+    /// <param name="serviceProvider">An instance object of a mechanism for retrieving a service object.</param>
+    /// <param name="cancellationToken">An optional CancellationToken object that can be used to cancel the 
+    /// this operation.</param>
+    /// <returns><see cref="TestStep"/> object.</returns>
+    public override Task HandleAsync(
+        Uri url,
+        TestSettings settings,
+        TestContext context,
+        IServiceProvider serviceProvider,
+        CancellationToken cancellationToken = default)
+    {
+        return _client switch
+        {
+            Client.HttpClient => _httpClientRequestSender.Value.HandleAsync(
+                url, settings, context, serviceProvider, cancellationToken),
+            Client.HeadlessBrowser => _headlessBrowserRequestSender.Value.HandleAsync(
+                url, settings, context, serviceProvider, cancellationToken),
+            _ => throw new NotSupportedException(Errors.IncorrectClientType)
+        };
+    }
+}

--- a/src/XPing365.Sdk.Availability/TestActions/Internals/HeadlessBrowserRequestSender.cs
+++ b/src/XPing365.Sdk.Availability/TestActions/Internals/HeadlessBrowserRequestSender.cs
@@ -7,7 +7,7 @@ using XPing365.Sdk.Core.Session;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http.Headers;
 
-namespace XPing365.Sdk.Availability.TestActions;
+namespace XPing365.Sdk.Availability.TestActions.Internals;
 
 /// <summary>
 /// The HeadlessBrowserRequestSender class is a subclass of the TestComponent abstract class that implements the 
@@ -23,10 +23,8 @@ namespace XPing365.Sdk.Availability.TestActions;
 /// factory by implementing the <see cref="IHeadlessBrowserFactory"/> interface and adding its implementation into
 /// services.
 /// </remarks>
-public sealed class HeadlessBrowserRequestSender() : TestComponent(name: StepName, type: TestStepType.ActionStep)
+internal sealed class HeadlessBrowserRequestSender(string name) : TestComponent(name, type: TestStepType.ActionStep)
 {
-    public const string StepName = "Headless browser request";
-
     /// <summary>
     /// This method performs the test step operation asynchronously.
     /// </summary>

--- a/src/XPing365.Sdk.Availability/TestActions/Internals/HttpClientRequestSender.cs
+++ b/src/XPing365.Sdk.Availability/TestActions/Internals/HttpClientRequestSender.cs
@@ -6,7 +6,7 @@ using XPing365.Sdk.Core.Configurations;
 using XPing365.Sdk.Core.DependencyInjection;
 using XPing365.Sdk.Core.Session;
 
-namespace XPing365.Sdk.Availability.TestActions;
+namespace XPing365.Sdk.Availability.TestActions.Internals;
 
 /// <summary>
 /// The HttpClientRequestSender class is a concrete implementation of the <see cref="TestComponent"/> class that is used 
@@ -18,10 +18,8 @@ namespace XPing365.Sdk.Availability.TestActions;
 /// <see cref="DependencyInjectionExtension.AddHttpClients(IServiceCollection, Action{IServiceProvider, HttpClientConfiguration}?)(IServiceCollection)"/>
 /// method.
 /// </remarks>
-public sealed class HttpClientRequestSender() : TestComponent(name: StepName, type: TestStepType.ActionStep)
+internal sealed class HttpClientRequestSender(string name) : TestComponent(name, type: TestStepType.ActionStep)
 {
-    public const string StepName = "Send HTTP Request";
-
     /// <summary>
     /// This method performs the test step operation asynchronously.
     /// </summary>

--- a/src/XPing365.Sdk.Core/Common/Errors.cs
+++ b/src/XPing365.Sdk.Core/Common/Errors.cs
@@ -33,6 +33,13 @@ public static class Errors
             $"`AddBrowserClients()` to add them before you can use them.");
 
     /// <summary>
+    /// Creates an error when incorrect client type has been given for Http Request System
+    /// </summary>
+    /// <returns>An error with code 1012 and a message instructing to use HttpClient or HeadlessBrowser</returns>
+    public static Error IncorrectClientType =>
+        new("1012", $"The client type is not supported. Please use either HttpClient or HeadlessBrowser.");    
+
+    /// <summary>
     /// Creates an error when there is insufficient data to perform a test step
     /// </summary>
     /// <param name="component">The test component that requires data</param>

--- a/src/XPing365.Sdk.Core/Components/Client.cs
+++ b/src/XPing365.Sdk.Core/Components/Client.cs
@@ -1,0 +1,20 @@
+﻿namespace XPing365.Sdk.Core;
+
+/// <summary>
+/// An enum that represents the type of client used to send HTTP requests
+/// </summary>
+public enum Client
+{
+    /// <summary>
+    /// A client that uses the <see cref="HttpClient"> class
+    /// </summary>
+    HttpClient,
+
+    /// <summary>
+    /// A client that uses a headless browser from Playwright
+    /// </summary>
+    /// <remarks>
+    /// Playwright is a library that allows controlling Chromium, WebKit, or Firefox browsers
+    /// </remarks>
+    HeadlessBrowser
+}

--- a/src/XPing365.Sdk.Core/Components/TestComponent.cs
+++ b/src/XPing365.Sdk.Core/Components/TestComponent.cs
@@ -19,7 +19,7 @@ public abstract class TestComponent : ITestComponent
     /// <summary>
     /// Gets a step name.
     /// </summary>
-    public string Name { get; }
+    public string Name { get; protected set; }
 
     /// <summary>
     /// Gets a step type.

--- a/tests/XPing365.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
@@ -146,7 +146,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
 
         // Assert
         Assert.That(session.Steps.Any(step =>
-            step.Name == HttpClientRequestSender.StepName &&
+            step.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture) &&
             step.Result == TestStepResult.Failed &&
             step.ErrorMessage == expectedErrMsg), Is.True);
     }

--- a/tests/XPing365.Sdk.IntegrationTests/BrowserTestAgentTests.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/BrowserTestAgentTests.cs
@@ -184,7 +184,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
             ResponseBuilder, settings: settings).ConfigureAwait(false);
 
         var failedStep = session.Steps.FirstOrDefault(step =>
-            step.Name == HeadlessBrowserRequestSender.StepName &&
+            step.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture) &&
             step.Result == TestStepResult.Failed);
 
         // Assert

--- a/tests/XPing365.Sdk.IntegrationTests/TestFixtures/TestFixtureProvider.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/TestFixtures/TestFixtureProvider.cs
@@ -33,7 +33,7 @@ public static class TestFixtureProvider
                         components: [
                             new DnsLookup(),
                             new IPAddressAccessibilityCheck(),
-                            new HttpClientRequestSender()
+                            new HttpRequestSender(Client.HttpClient)
                         ]);
                     return agent;
                 });
@@ -45,7 +45,7 @@ public static class TestFixtureProvider
                         components: [
                             new DnsLookup(),
                             new IPAddressAccessibilityCheck(),
-                            new HeadlessBrowserRequestSender()
+                            new HttpRequestSender(Client.HeadlessBrowser)
                         ]);
                     return agent;
                 });


### PR DESCRIPTION
This PR refactors the Http Request System to provide a unified interface for sending HTTP requests using either HttpClient or Headless browser. Users can specify the desired client type in the constructor parameter of the HttpRequestSender class. If no client type is provided, the HttpRequestSender class will use HttpClient by default.

The `HttpRequestSender` class is a subclass of the `TestComponent` abstract class that implements the `HandleAsync` method. Depending on the client type, it will delegate the request handling to either the `HttpClientRequestSender` or the `HeadlessBrowserRequestSender` class, which are also subclasses of the TestComponent abstract class. These classes are moved to the Internals namespace to avoid exposing them to the users.

The `HttpClientRequestSender` class uses the `HttpClient` class to send and receive HTTP requests and responses. It is fast, lightweight, and easy to use. However, it does not process HTML responses or run JavaScript code, which may limit its ability to validate server responses.

The `HeadlessBrowserRequestSender` class uses a headless browser from Playwright to send and receive HTTP requests and responses. It can render web pages and execute JavaScript code, which is useful for simulating user interactions and testing dynamic web applications. However, it is slower, heavier, and more complex than `HttpClient`.

This PR also updates the docs, samples, and tests to reflect the changes in the Http Request System. It also adds a new enum called `Client` that represents the type of client used to send HTTP requests, and a new error message for incorrect client type.