### PR TITLE
Ensure headless browsers are installed for testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Build
       run: dotnet build -c Release --no-restore
     - name: Test
-      run: dotnet test -c Release --no-build --verbosity normal 
+      run: dotnet test ./tests/XPing365.Sdk.IntegrationTests/XPing365.Sdk.IntegrationTests.csproj -c Release --no-build --verbosity normal 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,11 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.x
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build -c Release --no-restore
+    - name: Ensure browsers are installed
+      run: pwsh ./tests/XPing365.Sdk.IntegrationTests/bin/Release/net8.0/playwright.ps1 install --with-deps
     - name: Test
-      run: dotnet test ./tests/XPing365.Sdk.Core.UnitTests/XPing365.Sdk.Core.UnitTests.csproj -c Release --no-build --verbosity normal 
+      run: dotnet test ./tests/XPing365.Sdk.IntegrationTests/XPing365.Sdk.IntegrationTests.csproj -c Release --no-build --verbosity normal 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Build
       run: dotnet build -c Release --no-restore
     - name: Test
-      run: dotnet test ./tests/XPing365.Sdk.IntegrationTests/XPing365.Sdk.IntegrationTests.csproj -c Release --no-build --verbosity normal 
+      run: dotnet test ./tests/XPing365.Sdk.Core.UnitTests/XPing365.Sdk.Core.UnitTests.csproj -c Release --no-build --verbosity normal 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Ensure browsers are installed
       run: pwsh ./tests/XPing365.Sdk.IntegrationTests/bin/Release/net8.0/playwright.ps1 install --with-deps
     - name: Test
-      run: dotnet test ./tests/XPing365.Sdk.IntegrationTests/XPing365.Sdk.IntegrationTests.csproj -c Release --no-build --verbosity normal 
+      run: dotnet test -c Release --no-build --verbosity normal 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,4 @@ jobs:
       run: pwsh ./tests/XPing365.Sdk.IntegrationTests/bin/Release/net8.0/playwright.ps1 install --with-deps
     - name: Test
       run: dotnet test ./tests/XPing365.Sdk.IntegrationTests/XPing365.Sdk.IntegrationTests.csproj -c Release --no-build --verbosity normal 
+# blablabla

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,3 @@ jobs:
       run: pwsh ./tests/XPing365.Sdk.IntegrationTests/bin/Release/net8.0/playwright.ps1 install --with-deps
     - name: Test
       run: dotnet test ./tests/XPing365.Sdk.IntegrationTests/XPing365.Sdk.IntegrationTests.csproj -c Release --no-build --verbosity normal 
-# blablabla

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -51,8 +51,6 @@ public sealed class Program
         return await command.InvokeAsync(args).ConfigureAwait(false);
     }
 
-    // Test
-
     static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureServices((services) =>

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -51,6 +51,8 @@ public sealed class Program
         return await command.InvokeAsync(args).ConfigureAwait(false);
     }
 
+    // Test
+
     static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureServices((services) =>

--- a/tests/XPing365.Sdk.IntegrationTests/BrowserTestAgentTests.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/BrowserTestAgentTests.cs
@@ -259,7 +259,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
         TestSession session = await testAgent
             .RunAsync(
                 url: InMemoryHttpServer.GetTestServerAddress(),
-                settings: settings ?? TestSettings.DefaultForHttpClient,
+                settings: settings ?? TestSettings.DefaultForBrowser,
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 


### PR DESCRIPTION
This PR resolves the issue of the CI workflow failing due to missing headless browsers. Previously, the check for headless browsers was not properly executed and caused the test step in CI to fail at some point. This PR ensures that the headless browsers are installed correctly before running the tests.