### PR TITLE
Report HTTP redirects in TestSession

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,6 @@ To get started with <b>XPing365</b> SDK, please refer to the following resources
 
 3. [Samples](https://github.com/XPing365/xping365-sdk/tree/main/samples): The <b>XPing365</b> SDK repository contains several samples that demonstrate how to use <b>XPing365</b> in various scenarios. You can find the samples in the `samples` directory of the repository.
 
-We hope that you find XPing365 useful for your web application testing needs. If you have any questions or feedback, please don’t hesitate to reach out to us [here](https://github.com/XPing365/xping365-sdk/issues)!
+We hope that you find XPing365 useful for your web application testing needs. If you have any questions or feedback, please don’t hesitate to reach out to us [here](https://github.com/XPing365/xping365-sdk/discussions)!
 
 Thank you for using <b>XPing365</b>!

--- a/samples/IntegrationTesting/IndexPageTests.cs
+++ b/samples/IntegrationTesting/IndexPageTests.cs
@@ -78,3 +78,39 @@ public partial class IndexPageTests : WebAppIntegrationTestFixture
         Assert.That(session.IsValid, Is.True, session.Failures.FirstOrDefault()?.ErrorMessage);
     }
 }
+
+
+/* Suggested test structure with helper methods to simplify testing
+
+public class ConsoleAppTesting : TestBase
+{
+    public ConsoleAppTesting() : base()
+    {
+        // Register the components for the testing pipeline
+        RegisterComponent(new HttpRequestSender());
+        RegisterComponent(new ResponseContentValidator());
+        RegisterComponent(new ResponseStatusCodeValidator());
+    }
+
+    [Test]
+    public void TestWebAddress()
+    {
+        // Get the web address from the command line argument
+        string webAddress = GetArgumentValue("--url");
+
+        // Set the request URL
+        SetRequestUrl(webAddress);
+
+        // Set the expected response content
+        SetExpectedResponseContent("Welcome to XPing365");
+
+        // Set the expected response status code
+        SetExpectedResponseStatusCode(200);
+
+        // Run the testing pipeline
+        RunPipeline();
+    }
+}
+
+
+*/

--- a/samples/README.md
+++ b/samples/README.md
@@ -88,7 +88,7 @@ This folder contains the following sample projects:
 - It verifies if the web application is up and running after deployment, which ensures the quality and reliability of your product. You can set the expected response content and status code in the code and compare them with the actual response from the web address. For example, you can set the expected response content to `"Welcome to XPing365"` and the expected response status code to `200` and check if they match the actual response from the web address.
 - It warms up the web application by hitting different routes, which improves the performance and user experience of your product right after deployment. You can provide web addresses with different paths that access different parts of your web application and make sure they are loaded and ready to use. For example, you can provide web addresses like https://example.com/home, https://example.com/about, and https://example.com/contact.
 
-I hope this project helps you with your testing needs. If you have any feedback or questions, please let me know [here](https://github.com/XPing365/xping365-sdk/discussions/29). 😊
+We hope this project helps you with your testing needs. If you have any feedback or questions, please let us know [here](https://github.com/XPing365/xping365-sdk/discussions/29). 😊
 
 ### IntegrationTesting Sample
 
@@ -101,4 +101,4 @@ With this project, you can:
 > [!NOTE] 
 > Running the Web Application in memory prevents you from using headless browsers in this testing scenario.
 
-I hope this project helps you with your testing needs. If you have any feedback or questions, please let me know [here](https://github.com/XPing365/xping365-sdk/discussions/29). 😊
+We hope this project helps you with your testing needs. If you have any feedback or questions, please let us know [here](https://github.com/XPing365/xping365-sdk/discussions/29). 😊

--- a/src/XPing365.Sdk.Availability/TestActions/Internals/HeadlessBrowserRequestSender.cs
+++ b/src/XPing365.Sdk.Availability/TestActions/Internals/HeadlessBrowserRequestSender.cs
@@ -119,6 +119,7 @@ internal sealed class HeadlessBrowserRequestSender(string name) : TestComponent(
             .Build(PropertyBagKeys.HttpReasonPhrase, new PropertyBagValue<string?>(response.StatusText))
             .Build(PropertyBagKeys.HttpResponseHeaders, responseHeadersBag)
             .Build(component: this, instrumentation);
+        context.Progress?.Report(testStep);
 
         // Location HTTP header, specifies the absolute or relative URL of the new resource.
         if (responseHeadersBag.Value.TryGetValue(HeaderNames.Location.ToUpperInvariant(), out string? redirectUrl))
@@ -143,8 +144,6 @@ internal sealed class HeadlessBrowserRequestSender(string name) : TestComponent(
 
         // Restart the instrumentation log after this test step to ensure accurate timing for subsequent steps.
         instrumentation.Restart();
-
-        context.Progress?.Report(testStep);
     }
 
     private static PropertyBagValue<Dictionary<string, string>> GetHeaders(HttpHeaders headers) =>

--- a/src/XPing365.Sdk.Availability/TestActions/Internals/OrderedHttpRedirections.cs
+++ b/src/XPing365.Sdk.Availability/TestActions/Internals/OrderedHttpRedirections.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections;
+
+namespace XPing365.Sdk.Availability.TestActions.Internals;
+
+internal class OrderedHttpRedirections : IEnumerable<string>
+{
+    private readonly HashSet<string> _hashSet = [];
+    private readonly List<string> _insertionOrder = [];
+
+    public int Count => _hashSet.Count;
+
+    // Add items to HashSet and track order of insertion
+    public bool Add(string url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+
+        if (_hashSet.Add(url))
+        {
+            _insertionOrder.Add(url);
+            return true;
+        }
+
+        return false;
+    }
+
+    // Find first item matching a condition starting from the end
+    public string? FindLastMatchingItem(Func<string, bool> matchCondition)
+    {
+        for (int i = _insertionOrder.Count - 1; i >= 0; i--)
+        {
+            if (matchCondition(_insertionOrder[i]))
+            {
+                return _insertionOrder[i];
+            }
+        }
+
+        return null;
+    }
+
+    public void Clear()
+    {
+        _hashSet.Clear();
+        _insertionOrder.Clear();
+    }
+
+    public IEnumerator<string> GetEnumerator()
+    {
+        return ((IEnumerable<string>)this._insertionOrder).GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return ((IEnumerable)this._insertionOrder).GetEnumerator();
+    }
+}

--- a/src/XPing365.Sdk.Core/Components/TestSettings.cs
+++ b/src/XPing365.Sdk.Core/Components/TestSettings.cs
@@ -33,6 +33,11 @@ public sealed class TestSettings
     public bool FollowHttpRedirectionResponses { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets the maximum number of allowed HTTP redirects. Default is 50.
+    /// </summary>
+    public int MaxRedirections { get; set; } = 50;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to continue running all tests regardless of their results. Default is 
     /// false.
     /// </summary>

--- a/src/XPing365.Sdk.Core/Configurations/HttpClientConfiguration.cs
+++ b/src/XPing365.Sdk.Core/Configurations/HttpClientConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace XPing365.Sdk.Core.Configurations;
+﻿using System.Net;
+
+namespace XPing365.Sdk.Core.Configurations;
 
 /// <summary>
 /// The HttpClientConfiguration class is used to provide a set of properties for various features of 
@@ -7,10 +9,8 @@
 /// </summary>
 public class HttpClientConfiguration
 {
-    public const string HttpClientWithNoRetryAndFollowRedirect = nameof(HttpClientWithNoRetryAndFollowRedirect);
     public const string HttpClientWithNoRetryAndNoFollowRedirect = nameof(HttpClientWithNoRetryAndNoFollowRedirect);
     public const string HttpClientWithRetryAndNoFollowRedirect = nameof(HttpClientWithRetryAndNoFollowRedirect);
-    public const string HttpClientWithRetryAndFollowRedirect = nameof(HttpClientWithRetryAndFollowRedirect);
 
     /// <summary>
     /// Gets or sets how long a connection can be in the pool to be considered reusable. Default is 1 minute.
@@ -40,4 +40,10 @@ public class HttpClientConfiguration
     /// See the remarks on <see cref="Microsoft.Extensions.Http.PolicyHttpMessageHandler"/>.
     /// </summary>
     public TimeSpan DurationOfBreak { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets a type of decompression method used by the handler for automatic decompression of the HTTP content
+    /// response. Default is All.
+    /// </summary>
+    public DecompressionMethods AutomaticDecompression { get; set; } = DecompressionMethods.All;
 }

--- a/src/XPing365.Sdk.Core/DependencyInjection/DependencyInjectionExtension.cs
+++ b/src/XPing365.Sdk.Core/DependencyInjection/DependencyInjectionExtension.cs
@@ -27,50 +27,13 @@ public static class DependencyInjectionExtension
         services.AddHttpClient(HttpClientConfiguration.HttpClientWithNoRetryAndNoFollowRedirect)
                 .ConfigurePrimaryHttpMessageHandler(configureHandler =>
                 {
-                    return new SocketsHttpHandler
-                    {
-                        PooledConnectionLifetime = httpClientConfiguration.PooledConnectionLifetime,
-                        AllowAutoRedirect = false,
-                        UseCookies = false, // Set the cookie manually instead from the CookieContainer
-                    };
-                });
-
-        services.AddHttpClient(HttpClientConfiguration.HttpClientWithNoRetryAndFollowRedirect)
-                .ConfigurePrimaryHttpMessageHandler(configureHandler =>
-                {
-                    return new SocketsHttpHandler
-                    {
-                        PooledConnectionLifetime = httpClientConfiguration.PooledConnectionLifetime,
-                        AllowAutoRedirect = true,
-                        UseCookies = false, // Set the cookie manually instead from the CookieContainer
-                    };
+                    return CreateSocketsHttpHandler(httpClientConfiguration);
                 });
 
         services.AddHttpClient(HttpClientConfiguration.HttpClientWithRetryAndNoFollowRedirect)
                 .ConfigurePrimaryHttpMessageHandler(configureHandler =>
                 {
-                    return new SocketsHttpHandler
-                    {
-                        PooledConnectionLifetime = httpClientConfiguration.PooledConnectionLifetime,
-                        AllowAutoRedirect = false,
-                        UseCookies = false, // Set the cookie manually instead from the CookieContainer
-                    };
-                })
-                .AddTransientHttpErrorPolicy(builder => builder.WaitAndRetryAsync(
-                    sleepDurations: httpClientConfiguration.SleepDurations))
-                .AddTransientHttpErrorPolicy(builder => builder.CircuitBreakerAsync(
-                    handledEventsAllowedBeforeBreaking: httpClientConfiguration.HandledEventsAllowedBeforeBreaking,
-                    durationOfBreak: httpClientConfiguration.DurationOfBreak));
-
-        services.AddHttpClient(HttpClientConfiguration.HttpClientWithRetryAndFollowRedirect)
-                .ConfigurePrimaryHttpMessageHandler(configureHandler =>
-                {
-                    return new SocketsHttpHandler
-                    {
-                        PooledConnectionLifetime = httpClientConfiguration.PooledConnectionLifetime,
-                        AllowAutoRedirect = true,
-                        UseCookies = false, // Set the cookie manually instead from the CookieContainer
-                    };
+                    return CreateSocketsHttpHandler(httpClientConfiguration);
                 })
                 .AddTransientHttpErrorPolicy(builder => builder.WaitAndRetryAsync(
                     sleepDurations: httpClientConfiguration.SleepDurations))
@@ -128,4 +91,14 @@ public static class DependencyInjectionExtension
 
         return services;
     }
+
+
+    private static SocketsHttpHandler CreateSocketsHttpHandler(
+        HttpClientConfiguration httpClientConfiguration) => new()
+        {
+            PooledConnectionLifetime = httpClientConfiguration.PooledConnectionLifetime,
+            AutomaticDecompression = httpClientConfiguration.AutomaticDecompression,
+            AllowAutoRedirect = false, // We implement custom redirection mechanism
+            UseCookies = false, // Set the cookie manually instead from the CookieContainer
+        };
 }

--- a/src/XPing365.Sdk.Core/HeadlessBrowser/BrowserContext.cs
+++ b/src/XPing365.Sdk.Core/HeadlessBrowser/BrowserContext.cs
@@ -27,6 +27,17 @@ public class BrowserContext
     public string? UserAgent { get; set; }
 
     /// <summary>
+    /// Gets or sets the maximum number of allowed HTTP redirects. Default is 50.
+    /// </summary>
+    public int MaxRedirections { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets a boolean value which determines whether to follow HTTP redirection responses. Default is true, 
+    /// unless specified differently in <see cref="DefaultForHttpClient"/>.
+    /// </summary>
+    public bool FollowHttpRedirectionResponses { get; set; } = true;
+
+    /// <summary>
     /// Emulates consistent viewport for each page. Defaults to an 1280x720 viewport.
     /// Learn more about <a href="https://playwright.dev/dotnet/docs/emulation#viewport">viewport emulation</a>.
     /// </summary>

--- a/src/XPing365.Sdk.Core/HeadlessBrowser/Internals/WebPageBuilder.cs
+++ b/src/XPing365.Sdk.Core/HeadlessBrowser/Internals/WebPageBuilder.cs
@@ -41,7 +41,10 @@ internal sealed partial class WebPageBuilder
         var responseMessage = new HttpResponseMessage
         {
             StatusCode = (HttpStatusCode)_response.Status,
-            Content = new StringContent(await _page.ContentAsync().ConfigureAwait(false))
+            Content = new StringContent(await _page.ContentAsync().ConfigureAwait(false)),
+            RequestMessage = new HttpRequestMessage(
+                HttpMethod.Parse(_response.Request.Method),
+                new Uri(_page.Url))
         };
 
         foreach (var httpHeader in _response.Headers)

--- a/src/XPing365.Sdk.Core/HeadlessBrowser/TooManyRedirectsException.cs
+++ b/src/XPing365.Sdk.Core/HeadlessBrowser/TooManyRedirectsException.cs
@@ -1,0 +1,41 @@
+﻿using System.Net;
+
+namespace XPing365.Sdk.Core.HeadlessBrowser;
+
+/// <summary>
+/// Represents errors that occur when an HTTP request is redirected more times than the set limit.
+/// </summary>
+/// <remarks>
+/// This exception is thrown when an HTTP operation encounters more redirects than the application allows.
+/// It inherits from the <see cref="WebException"/> class and adds no new functionality; instead, it provides a more 
+/// specific exception type to handle excessive HTTP redirection scenarios.
+/// </remarks>
+public class TooManyRedirectsException : WebException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TooManyRedirectsException"/> class.
+    /// </summary>
+    public TooManyRedirectsException()
+    {}
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TooManyRedirectsException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public TooManyRedirectsException(string message)
+        : base(message)
+    {}
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TooManyRedirectsException"/> class with a specified error message 
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="inner">
+    /// The exception that is the cause of the current exception, or a null reference if no inner 
+    /// exception is specified.
+    /// </param>
+    public TooManyRedirectsException(string message, Exception inner)
+        : base(message, inner)
+    {}
+}

--- a/tests/XPing365.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
@@ -241,6 +241,252 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
         Mock.Get(mockProgress!).Verify(p => p.Report(It.IsAny<TestStep>()), Times.Exactly(session.Steps.Count));
     }
 
+    [Test]
+    public async Task HttpRequestSenderComponentFollowsRedirectWhenConfigured()
+    {
+        // Arrange
+        string destinationServerAddress = "http://localhost:8081/";
+        HttpStatusCode redirectionStatus = HttpStatusCode.MovedPermanently;
+
+        using Task destinationServer = InMemoryHttpServer.TestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.OK;
+                response.Close(); // By closing a response it can be send to client.
+            },
+            requestReceived: (request) => { },
+            uriPrefixes: [new Uri(destinationServerAddress)]);
+
+        var settings = TestSettings.DefaultForHttpClient;
+        settings.FollowHttpRedirectionResponses = true;
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)redirectionStatus;
+                response.Headers.Add(HeaderNames.Location, destinationServerAddress);
+                response.Close(); // By closing a response it can be send to client.
+            }, settings: settings).ConfigureAwait(false);
+
+        await destinationServer.WaitAsync(cancellationToken: default).ConfigureAwait(false);
+
+        // Assert
+        var httpRequestSteps = session.Steps.Where(s => 
+            s.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture)).ToList();
+        var redirectionStep = httpRequestSteps.First();
+        var destinationStep = httpRequestSteps.Last();
+
+        var redirectionStatusCode = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
+            PropertyBagKeys.HttpStatus).Value;
+        var redirectionUrl = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<Dictionary<string, string>>>(
+            PropertyBagKeys.HttpResponseHeaders).Value[HeaderNames.Location.ToUpperInvariant()];
+        var destinationStatusCode = destinationStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
+            PropertyBagKeys.HttpStatus).Value;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(httpRequestSteps, Has.Count.EqualTo(2));
+            Assert.That(redirectionStep, Is.Not.Null);
+            Assert.That(redirectionStatusCode, Is.EqualTo($"{(int)redirectionStatus}"));
+            Assert.That(redirectionUrl, Is.EqualTo(destinationServerAddress));
+            Assert.That(destinationStep, Is.Not.Null);
+            Assert.That(destinationStatusCode, Is.EqualTo($"{(int)HttpStatusCode.OK}"));
+        });
+    }
+
+    [Test]
+    public async Task HttpRequestSenderComponentDetectsCircularDependency()
+    {
+        // Arrange
+        // The redirect URL is on the same server as the original URL
+        string destinationServerAddress = InMemoryHttpServer.GetTestServerAddress().AbsoluteUri;
+
+        var settings = TestSettings.DefaultForHttpClient;
+        settings.FollowHttpRedirectionResponses = true;
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.MovedPermanently;
+                response.Headers.Add(HeaderNames.Location, destinationServerAddress);
+                response.Close(); // By closing a response it can be send to client.
+            }, settings: settings).ConfigureAwait(false);
+
+        // Assert
+        var httpRequestSteps = session.Steps.Where(s =>
+            s.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture)).ToList();
+        var redirectionStep = httpRequestSteps.First();
+        var destinationStep = httpRequestSteps.Last();
+
+        var redirectionStatusCode = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
+            PropertyBagKeys.HttpStatus).Value;
+        var redirectionUrl = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<Dictionary<string, string>>>(
+            PropertyBagKeys.HttpResponseHeaders).Value[HeaderNames.Location.ToUpperInvariant()];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(httpRequestSteps, Has.Count.EqualTo(2));
+            Assert.That(redirectionStep, Is.Not.Null);
+            Assert.That(redirectionStep.Result, Is.EqualTo(TestStepResult.Succeeded));
+            Assert.That(destinationStep.Result, Is.EqualTo(TestStepResult.Failed));
+            Assert.That(destinationStep.ErrorMessage, Does.Contain("A circular dependency was detected for the " +
+                "URL http://localhost:8080/. The redirection chain is: http://localhost:8080/"));
+        });
+    }
+
+    [Test]
+    public async Task HttpRequestSenderComponentReportsProgressForAllItsStepsWhenRedirectionHappens()
+    {
+        // Arrange
+        var mockProgress = _serviceProvider.GetService<IProgress<TestStep>>();
+
+        // The redirect URL is on the same server as the original URL
+        string destinationServerAddress = InMemoryHttpServer.GetTestServerAddress().AbsoluteUri;
+        var settings = TestSettings.DefaultForHttpClient;
+        settings.FollowHttpRedirectionResponses = true;
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.MovedPermanently;
+                response.Headers.Add(HeaderNames.Location, destinationServerAddress);
+                response.Close(); // By closing a response it can be send to client.
+            }, settings: settings).ConfigureAwait(false);
+
+        // Assert
+        Mock.Get(mockProgress!).Verify(p => p.Report(It.IsAny<TestStep>()), Times.Exactly(session.Steps.Count));
+    }
+
+    [Test]
+    public async Task HttpRequestSenderComponentRestrictsNumberOfRedirectionsWhenConfigured()
+    {
+        // Arrange two HTTP redirections localhost:8080 -> localhost:8081 -> localhost:8082
+        string destinationServerAddress = "http://localhost:8081/";
+        HttpStatusCode redirectionStatus = HttpStatusCode.MovedPermanently;
+
+        using Task destinationServer = InMemoryHttpServer.TestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.MovedPermanently;
+                response.Headers.Add(HeaderNames.Location, "http://localhost:8082/");
+                response.Close(); // By closing a response it can be send to client.
+            },
+            requestReceived: (request) => { },
+            uriPrefixes: [new Uri(destinationServerAddress)]);
+
+        var settings = TestSettings.DefaultForHttpClient;
+        settings.FollowHttpRedirectionResponses = true;
+        settings.MaxRedirections = 1;
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)redirectionStatus;
+                response.Headers.Add(HeaderNames.Location, destinationServerAddress);
+                response.Close(); // By closing a response it can be send to client.
+            }, settings: settings).ConfigureAwait(false);
+
+        await destinationServer.WaitAsync(cancellationToken: default).ConfigureAwait(false);
+
+        // Assert
+        var httpRequestSteps = session.Steps.Where(s =>
+            s.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture)).ToList();
+        var destinationStep = httpRequestSteps.Last();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(destinationStep.Result, Is.EqualTo(TestStepResult.Failed));
+            Assert.That(destinationStep.ErrorMessage, Does.Contain($"The maximum number of redirects " +
+                $"({settings.MaxRedirections}) has been exceeded for the URL http://localhost:8080/. The last " +
+                $"redirect URL was http://localhost:8081/"));
+        });
+    }
+
+    [Test]
+    public async Task HttpRequestSenderComponentFollowsRelativeRedirectedUrl()
+    {
+        bool redirected = false;
+
+        // Arrange
+        using Task redirectionServer = InMemoryHttpServer.TestServer(
+            responseBuilder: (response) =>
+            {
+                if (!redirected)
+                {
+                    response.StatusCode = (int)HttpStatusCode.Moved;
+                    response.Headers.Add(HeaderNames.Location, "/home");
+                    response.Close(); // By closing a response it can be send to client.
+                    redirected = true;
+                }
+                else
+                {
+                    response.StatusCode = (int)HttpStatusCode.OK;
+                    response.Close(); // By closing a response it can be send to client.
+                }
+            },
+            requestReceived: (request) => { },
+            uriPrefixes: [new Uri("http://localhost:8081/"), new Uri("http://localhost:8081/home/")]);
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.Moved;
+                response.Headers.Add(HeaderNames.Location, "http://localhost:8081/");
+                response.Close(); // By closing a response it can be send to client.
+            }).ConfigureAwait(false);
+
+        await redirectionServer.WaitAsync(cancellationToken: default).ConfigureAwait(false);
+
+        // Assert
+        var httpRequestSteps = session.Steps.Where(s =>
+            s.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture)).ToList();
+        var destinationStep = httpRequestSteps.Last();
+
+        var destinationStatusCode = destinationStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
+            PropertyBagKeys.HttpStatus).Value;
+        var destinationUrl = destinationStep.PropertyBag!.GetProperty<NonSerializable<HttpResponseMessage>>(
+            PropertyBagKeys.HttpResponseMessage).Value;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(httpRequestSteps, Has.Count.EqualTo(3));
+            Assert.That(destinationStep, Is.Not.Null);
+            Assert.That(destinationStatusCode, Is.EqualTo($"{(int)HttpStatusCode.OK}"));
+            Assert.That(destinationUrl, Is.Not.Null);
+            Assert.That(destinationUrl.RequestMessage!.RequestUri!.AbsoluteUri, 
+                Is.EqualTo($"http://localhost:8081/home"));
+        });
+    }
+
+    [Test]
+    public async Task HttpRequestSenderComponentDoesNotFollowHttpRedirectWhenFollowRedirectionIsDisabled()
+    {
+        // Arrange
+        string destinationServerAddress = "http://localhost:8080/destination";
+        var settings = TestSettings.DefaultForHttpClient;
+        settings.FollowHttpRedirectionResponses = false;
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.MovedPermanently;
+                response.Headers.Add(HeaderNames.Location, destinationServerAddress);
+                response.Close(); // By closing a response it can be send to client.
+            }, settings: settings).ConfigureAwait(false);
+
+        // Assert
+        var httpRequestSteps = session.Steps.Where(s =>
+            s.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture)).ToList();
+
+        Assert.That(httpRequestSteps, Has.Count.EqualTo(1));
+    }
+
     private async Task<TestSession> GetTestSessionFromInMemoryHttpTestServer(
         Action<HttpListenerResponse>? responseBuilder = null,
         Action<HttpListenerRequest>? requestReceived = null,

--- a/tests/XPing365.Sdk.IntegrationTests/BrowserTestAgentTests.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/BrowserTestAgentTests.cs
@@ -228,6 +228,253 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
         Assert.That(content.Contains(expectedText, StringComparison.InvariantCulture), Is.True);
     }
 
+    [Test]
+    public async Task HttpRequestSenderComponentFollowsRedirectWhenConfigured()
+    {
+        // Arrange
+        string destinationServerAddress = "http://localhost:8081/";
+        HttpStatusCode redirectionStatus = HttpStatusCode.MovedPermanently;
+
+        using Task destinationServer = InMemoryHttpServer.TestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.OK;
+                response.Close(); // By closing a response it can be send to client.
+            },
+            requestReceived: (request) => { },
+            uriPrefixes: [new Uri(destinationServerAddress)]);
+
+        var settings = TestSettings.DefaultForHttpClient;
+        settings.FollowHttpRedirectionResponses = true;
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)redirectionStatus;
+                response.Headers.Add(HeaderNames.Location, destinationServerAddress);
+                response.Close(); // By closing a response it can be send to client.
+            }, settings: settings).ConfigureAwait(false);
+
+        await destinationServer.WaitAsync(cancellationToken: default).ConfigureAwait(false);
+
+        // Assert
+        var httpRequestSteps = session.Steps.Where(s =>
+            s.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture)).ToList();
+        var redirectionStep = httpRequestSteps.First();
+        var destinationStep = httpRequestSteps.Last();
+
+        var redirectionStatusCode = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
+            PropertyBagKeys.HttpStatus).Value;
+        var redirectionUrl = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<Dictionary<string, string>>>(
+            PropertyBagKeys.HttpResponseHeaders).Value[HeaderNames.Location.ToUpperInvariant()];
+        var destinationStatusCode = destinationStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
+            PropertyBagKeys.HttpStatus).Value;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(httpRequestSteps, Has.Count.EqualTo(2));
+            Assert.That(redirectionStep, Is.Not.Null);
+            Assert.That(redirectionStatusCode, Is.EqualTo($"{(int)redirectionStatus}"));
+            Assert.That(redirectionUrl, Is.EqualTo(destinationServerAddress));
+            Assert.That(destinationStep, Is.Not.Null);
+            Assert.That(destinationStatusCode, Is.EqualTo($"{(int)HttpStatusCode.OK}"));
+        });
+    }
+
+    [Test]
+    public async Task HttpRequestSenderComponentDetectsCircularDependency()
+    {
+        // Arrange
+        // The redirect URL is on the same server as the original URL
+        string destinationServerAddress = InMemoryHttpServer.GetTestServerAddress().AbsoluteUri;
+
+        var settings = TestSettings.DefaultForHttpClient;
+        settings.FollowHttpRedirectionResponses = true;
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.MovedPermanently;
+                response.Headers.Add(HeaderNames.Location, destinationServerAddress);
+                response.Close(); // By closing a response it can be send to client.
+            }, settings: settings).ConfigureAwait(false);
+
+        // Assert
+        var httpRequestSteps = session.Steps.Where(s =>
+            s.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture)).ToList();
+        var redirectionStep = httpRequestSteps.First();
+        var destinationStep = httpRequestSteps.Last();
+
+        var redirectionStatusCode = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
+            PropertyBagKeys.HttpStatus).Value;
+        var redirectionUrl = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<Dictionary<string, string>>>(
+            PropertyBagKeys.HttpResponseHeaders).Value[HeaderNames.Location.ToUpperInvariant()];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(httpRequestSteps, Has.Count.EqualTo(2));
+            Assert.That(redirectionStep, Is.Not.Null);
+            Assert.That(redirectionStep.Result, Is.EqualTo(TestStepResult.Succeeded));
+            Assert.That(destinationStep.Result, Is.EqualTo(TestStepResult.Failed));
+            Assert.That(destinationStep.ErrorMessage, Does.Contain("A circular dependency was detected for the " +
+                "URL http://localhost:8080/. The redirection chain is: http://localhost:8080/"));
+        });
+    }
+
+    [Test]
+    public async Task HttpRequestSenderComponentReportsProgressForAllItsStepsWhenRedirectionHappens()
+    {
+        // Arrange
+        var mockProgress = _serviceProvider.GetService<IProgress<TestStep>>();
+
+        // The redirect URL is on the same server as the original URL
+        string destinationServerAddress = InMemoryHttpServer.GetTestServerAddress().AbsoluteUri;
+        var settings = TestSettings.DefaultForHttpClient;
+        settings.FollowHttpRedirectionResponses = true;
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.MovedPermanently;
+                response.Headers.Add(HeaderNames.Location, destinationServerAddress);
+                response.Close(); // By closing a response it can be send to client.
+            }, settings: settings).ConfigureAwait(false);
+
+        // Assert
+        Mock.Get(mockProgress!).Verify(p => p.Report(It.IsAny<TestStep>()), Times.Exactly(session.Steps.Count));
+    }
+
+    [Test]
+    public async Task HttpRequestSenderComponentRestrictsNumberOfRedirectionsWhenConfigured()
+    {
+        // Arrange two HTTP redirections localhost:8080 -> localhost:8081 -> localhost:8082
+        string destinationServerAddress = "http://localhost:8081/";
+        HttpStatusCode redirectionStatus = HttpStatusCode.MovedPermanently;
+
+        using Task destinationServer = InMemoryHttpServer.TestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.MovedPermanently;
+                response.Headers.Add(HeaderNames.Location, "http://localhost:8082/");
+                response.Close(); // By closing a response it can be send to client.
+            },
+            requestReceived: (request) => { },
+            uriPrefixes: [new Uri(destinationServerAddress)]);
+
+        var settings = TestSettings.DefaultForHttpClient;
+        settings.FollowHttpRedirectionResponses = true;
+        settings.MaxRedirections = 1;
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)redirectionStatus;
+                response.Headers.Add(HeaderNames.Location, destinationServerAddress);
+                response.Close(); // By closing a response it can be send to client.
+            }, settings: settings).ConfigureAwait(false);
+
+        await destinationServer.WaitAsync(cancellationToken: default).ConfigureAwait(false);
+
+        // Assert
+        var httpRequestSteps = session.Steps.Where(s =>
+            s.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture)).ToList();
+        var destinationStep = httpRequestSteps.Last();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(destinationStep.Result, Is.EqualTo(TestStepResult.Failed));
+            Assert.That(destinationStep.ErrorMessage, Does.Contain($"The maximum number of redirects " +
+                $"({settings.MaxRedirections}) has been exceeded for the URL http://localhost:8080/. The last " +
+                $"redirect URL was http://localhost:8081/"));
+        });
+    }
+
+    [Test]
+    public async Task HttpRequestSenderComponentFollowsRelativeRedirectedUrl()
+    {
+        bool redirected = false;
+
+        // Arrange
+        using Task redirectionServer = InMemoryHttpServer.TestServer(
+            responseBuilder: (response) =>
+            {
+                if (!redirected)
+                {
+                    response.StatusCode = (int)HttpStatusCode.Moved;
+                    response.Headers.Add(HeaderNames.Location, "/home");
+                    response.Close(); // By closing a response it can be send to client.
+                    redirected = true;
+                }
+                else
+                {
+                    response.StatusCode = (int)HttpStatusCode.OK;
+                    response.Close(); // By closing a response it can be send to client.
+                }
+            },
+            requestReceived: (request) => { },
+            uriPrefixes: [new Uri("http://localhost:8081/"), new Uri("http://localhost:8081/home/")]);
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.Moved;
+                response.Headers.Add(HeaderNames.Location, "http://localhost:8081/");
+                response.Close(); // By closing a response it can be send to client.
+            }).ConfigureAwait(false);
+
+        await redirectionServer.WaitAsync(cancellationToken: default).ConfigureAwait(false);
+
+        // Assert
+        var httpRequestSteps = session.Steps.Where(s =>
+            s.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture)).ToList();
+        var destinationStep = httpRequestSteps.Last();
+
+        var destinationStatusCode = destinationStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
+            PropertyBagKeys.HttpStatus).Value;
+        var destinationUrl = destinationStep.PropertyBag!.GetProperty<NonSerializable<HttpResponseMessage>>(
+            PropertyBagKeys.HttpResponseMessage).Value;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(httpRequestSteps, Has.Count.EqualTo(3));
+            Assert.That(destinationStep, Is.Not.Null);
+            Assert.That(destinationStatusCode, Is.EqualTo($"{(int)HttpStatusCode.OK}"));
+            Assert.That(destinationUrl, Is.Not.Null);
+            Assert.That(destinationUrl.RequestMessage!.RequestUri!.AbsoluteUri,
+                Is.EqualTo($"http://localhost:8081/home"));
+        });
+    }
+
+    [Test]
+    [Ignore(reason: "https://github.com/XPing365/xping365-sdk/issues/35")]
+    public async Task HttpRequestSenderComponentDoesNotFollowHttpRedirectWhenFollowRedirectionIsDisabled()
+    {
+        // Arrange
+        string destinationServerAddress = "http://localhost:8080/destination";
+        var settings = TestSettings.DefaultForHttpClient;
+        settings.FollowHttpRedirectionResponses = false;
+
+        // Act
+        TestSession session = await GetTestSessionFromInMemoryHttpTestServer(
+            responseBuilder: (response) =>
+            {
+                response.StatusCode = (int)HttpStatusCode.MovedPermanently;
+                response.Headers.Add(HeaderNames.Location, destinationServerAddress);
+                response.Close(); // By closing a response it can be send to client.
+            }, settings: settings).ConfigureAwait(false);
+
+        // Assert
+        var httpRequestSteps = session.Steps.Where(s =>
+            s.Name.StartsWith(HttpRequestSender.StepName, StringComparison.InvariantCulture)).ToList();
+
+        Assert.That(httpRequestSteps, Has.Count.EqualTo(1));
+    }
+
     private async Task<TestSession> GetTestSessionFromInMemoryHttpTestServer(
         Action<HttpListenerResponse> responseBuilder,
         Action<HttpListenerRequest>? requestReceived = null,

--- a/tests/XPing365.Sdk.IntegrationTests/HttpServer/InMemoryHttpServer.cs
+++ b/tests/XPing365.Sdk.IntegrationTests/HttpServer/InMemoryHttpServer.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Diagnostics;
+using System.Net;
 
 namespace XPing365.Sdk.IntegrationTests.HttpServer;
 
@@ -18,15 +19,55 @@ internal static class InMemoryHttpServer
     {
         return Task.Run(async () =>
         {
-            using HttpListener listener = new();
-            listener.Prefixes.Add(GetTestServerAddress().AbsoluteUri);
-            listener.Start();
-            // GetContext method blocks while waiting for a request. 
-            HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
-            // Examine client request received
-            requestReceived?.Invoke(context.Request);
-            // Build HttpListenerResponse
-            responseBuilder(context.Response);
+            try
+            {
+                using HttpListener listener = new();
+                listener.Prefixes.Add(GetTestServerAddress().AbsoluteUri);
+                listener.Start();
+                // GetContext method blocks while waiting for a request. 
+                HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                // Examine client request received
+                requestReceived?.Invoke(context.Request);
+                // Build HttpListenerResponse
+                responseBuilder(context.Response);
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e);
+            }
+        }, cancellationToken);
+    }
+
+    public static Task TestServer(
+        Action<HttpListenerResponse> responseBuilder,
+        Action<HttpListenerRequest> requestReceived,
+        Uri[] uriPrefixes,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.Run(async () =>
+        {
+            try
+            {
+                using HttpListener listener = new();
+                uriPrefixes.ToList().ForEach(uriPrefix => listener.Prefixes.Add(uriPrefix.AbsoluteUri));
+                listener.Start();
+
+                // The TestServer is configured to handle all registered uriPrefixes, ensuring that it can serve
+                // requests to any of them during our Tests.
+                for (int i = 0; i < uriPrefixes.Length; i++)
+                {
+                    // GetContext method blocks while waiting for a request. 
+                    HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+                    // Examine client request received
+                    requestReceived?.Invoke(context.Request);
+                    // Build HttpListenerResponse
+                    responseBuilder(context.Response);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e);
+            }
         }, cancellationToken);
     }
 


### PR DESCRIPTION
This pull request introduces changes to the `TestSession` class to enhance its functionality by reporting HTTP redirects. Previously, the `TestSession` class did not provide visibility into the HTTP redirection process, making it difficult to debug issues related to unexpected redirect behavior.

**Key Changes:**
- Implemented logic to capture and log the details of HTTP redirects.
- Added mechanism to detect circular dependency
- Implemented logic to restrict number of redirects.
- Updated unit tests to cover the new reporting feature.