### PR TITLE
Resolve Issue #33 - Ensure Unique TestSession with GUID Assignment

### DIFF
--- a/src/XPing365.Sdk.Core/Session/TestSession.cs
+++ b/src/XPing365.Sdk.Core/Session/TestSession.cs
@@ -32,6 +32,14 @@ public sealed class TestSession : ISerializable, IDeserializationCallback
     private readonly DateTime _startDate;
 
     /// <summary>
+    /// Gets the unique identifier of the test session.
+    /// </summary>
+    /// <value>
+    /// A <see cref="Guid"/> value that represents the test session ID.
+    /// </value>
+    public Guid Id { get; private set; }
+
+    /// <summary>
     /// A Uri object that represents the URL of the page being validated.
     /// </summary>
     public required Uri Url
@@ -107,7 +115,9 @@ public sealed class TestSession : ISerializable, IDeserializationCallback
     /// Initializes a new instance of the <see cref="TestSession"/> class.
     /// </summary>
     public TestSession()
-    { }
+    {
+        Id = Guid.NewGuid();
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TestSession"/> class with serialized data.
@@ -122,6 +132,7 @@ public sealed class TestSession : ISerializable, IDeserializationCallback
     {
         ArgumentNullException.ThrowIfNull(info, nameof(info));
 
+        Id = (Guid)info.GetValue(nameof(Id), typeof(Guid)).RequireNotNull(nameof(Id));
         Url = (Uri)info.GetValue(nameof(Url), typeof(Uri)).RequireNotNull(nameof(Url));
         StartDate = (DateTime)info.GetValue(nameof(StartDate), typeof(DateTime)).RequireNotNull(nameof(StartDate));
         Steps = info.GetValue(nameof(Steps), typeof(TestStep[])) as TestStep[] ?? [];
@@ -153,6 +164,7 @@ public sealed class TestSession : ISerializable, IDeserializationCallback
 
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
     {
+        info.AddValue(nameof(Id), Id, typeof(Guid));
         info.AddValue(nameof(Url), Url, typeof(Uri));
         info.AddValue(nameof(StartDate), StartDate, typeof(DateTime));
         info.AddValue(nameof(Steps), Steps.ToArray(), typeof(TestStep[]));

--- a/tests/XPing365.Sdk.Core.UnitTests/Session/Serialization/TestSessionSerializationTests.cs
+++ b/tests/XPing365.Sdk.Core.UnitTests/Session/Serialization/TestSessionSerializationTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.Serialization;
-using System.Text;
 using System.Xml;
 using System.Xml.XPath;
 using XPing365.Sdk.Core.Common;
@@ -63,6 +62,35 @@ internal class TestSessionSerializationTests
     }
 
     [Test]
+    public void TestSessionIdIsSerialized()
+    {
+        // Arrange
+        TestSession session = new()
+        {
+            Url = new Uri("https://test"),
+            StartDate = DateTime.UtcNow,
+            State = TestSessionState.NotStarted,
+            Steps = []
+        };
+        var serializer = new TestSessionSerializer();
+        using var stream = new MemoryStream();
+        
+        // Act
+        serializer.Serialize(session, stream, SerializationFormat.XML);
+        stream.Position = 0;
+
+        using XmlReader xmlReader = XmlReader.Create(stream);
+        var document = new XPathDocument(xmlReader);
+        XPathNavigator navigator = document.CreateNavigator();
+        XPathNodeIterator nodes = navigator.Select(XPathExpression.Compile("//TestSession/Id"));
+
+        // Assert
+        Assert.That(nodes.MoveNext(), Is.True);
+        Assert.That(nodes.Current, Is.Not.Null);
+        Assert.That(nodes.Current.Value, Is.EqualTo(session.Id.ToString()));
+    }
+
+    [Test]
     public void TestSessionInstanceIsCorrectlySerializedToXml()
     {
         // Arrange
@@ -94,12 +122,10 @@ internal class TestSessionSerializationTests
         XPathNavigator navigator = document.CreateNavigator();
         XPathNodeIterator nodes = navigator.Select("/TestSession/Url");
 
-        while (nodes.MoveNext())
-        {
-            // Assert
-            Assert.That(nodes.Current, Is.Not.Null);
-            Assert.That(nodes.Current.Value, Is.EqualTo(session.Url.AbsoluteUri));
-        }
+        // Assert
+        Assert.That(nodes.MoveNext(), Is.True);
+        Assert.That(nodes.Current, Is.Not.Null);
+        Assert.That(nodes.Current.Value, Is.EqualTo(session.Url.AbsoluteUri));
     }
 
     [Test]

--- a/tests/XPing365.Sdk.Core.UnitTests/Session/Serialization/TestSessionSerializationTests.cs
+++ b/tests/XPing365.Sdk.Core.UnitTests/Session/Serialization/TestSessionSerializationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using System.Text;
 using System.Xml;
 using System.Xml.XPath;
 using XPing365.Sdk.Core.Common;
@@ -79,15 +80,23 @@ internal class TestSessionSerializationTests
         serializer.Serialize(session, stream, SerializationFormat.XML);
         stream.Position = 0;
 
-        using XmlReader xmlReader = XmlReader.Create(stream);
-        var document = new XPathDocument(xmlReader);
-        XPathNavigator navigator = document.CreateNavigator();
-        XPathNodeIterator nodes = navigator.Select(XPathExpression.Compile("//TestSession/Id"));
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        // Load the XML into an XmlDocument
+        var doc = new XmlDocument();
+        doc.Load(reader);
+        
+        // Create a NamespaceManager and add the namespace used in the XML
+        var namespaceManager = new XmlNamespaceManager(doc.NameTable);
+        namespaceManager.AddNamespace("ns", "http://schemas.datacontract.org/2004/07/XPing365.Sdk.Core.Session");
+
+        // Use the namespace prefix in the XPath expression to select the Id element
+        XmlNode? idNode = doc.SelectSingleNode("//ns:TestSession/Id", namespaceManager);
 
         // Assert
-        Assert.That(nodes.MoveNext(), Is.True);
-        Assert.That(nodes.Current, Is.Not.Null);
-        Assert.That(nodes.Current.Value, Is.EqualTo(session.Id.ToString()));
+        Assert.That(idNode, Is.Not.Null);
+        Assert.That(Guid.TryParse(idNode.InnerText, out _), Is.True);
+        Assert.That(Guid.Parse(idNode.InnerText), Is.EqualTo(session.Id));
     }
 
     [Test]
@@ -116,20 +125,29 @@ internal class TestSessionSerializationTests
         // Act
         serializer.Serialize(session, stream, SerializationFormat.XML);
         stream.Position = 0;
+        using var reader = new StreamReader(stream, Encoding.UTF8);
 
-        using XmlReader xmlReader = XmlReader.Create(stream);
-        var document = new XPathDocument(xmlReader);
-        XPathNavigator navigator = document.CreateNavigator();
-        XPathNodeIterator nodes = navigator.Select("/TestSession/Url");
+        // Load the XML into an XmlDocument
+        var doc = new XmlDocument();
+        doc.Load(reader);
+
+        // Create a NamespaceManager and add the namespace used in the XML
+        var namespaceManager = new XmlNamespaceManager(doc.NameTable);
+        namespaceManager.AddNamespace("ns", "http://schemas.datacontract.org/2004/07/XPing365.Sdk.Core.Session");
+
+        // Use the namespace prefix in the XPath expression to select the Url element
+        XmlNode? urlNode = doc.SelectSingleNode("//ns:TestSession/Url", namespaceManager);
 
         // Assert
-        Assert.That(nodes.MoveNext(), Is.True);
-        Assert.That(nodes.Current, Is.Not.Null);
-        Assert.That(nodes.Current.Value, Is.EqualTo(session.Url.AbsoluteUri));
+        Assert.That(urlNode, Is.Not.Null);
+        Assert.That(Uri.TryCreate(urlNode.InnerText, UriKind.Absolute, out _), Is.True);
+        Assert.That(new Uri(urlNode.InnerText), Is.EqualTo(session.Url));
     }
 
+    [TestCase(SerializationFormat.XML)]
+    [TestCase(SerializationFormat.Binary)]
     [Test]
-    public void TestSessionInstanceIsCorrectlyDeserializedFromXml()
+    public void TestSessionInstanceIsCorrectlyDeserialized(SerializationFormat format)
     {
         // Arrange
         TestSession session = new()
@@ -152,9 +170,9 @@ internal class TestSessionSerializationTests
         using var stream = new MemoryStream();
 
         // Act
-        serializer.Serialize(session, stream, SerializationFormat.XML);
+        serializer.Serialize(session, stream, format);
         stream.Position = 0;
-        TestSession? session1 = serializer.Deserialize(stream, SerializationFormat.XML);
+        TestSession? session1 = serializer.Deserialize(stream, format);
 
         // Assert
         Assert.That(session1, Is.Not.Null);
@@ -166,6 +184,33 @@ internal class TestSessionSerializationTests
         Assert.That(session1.Steps.First().PropertyBag, Is.Not.Null);
         Assert.That(session.Steps.First().StartDate, Is.EqualTo(session1.Steps.First().StartDate));
         Assert.That(session.Steps.First().Type, Is.EqualTo(session1.Steps.First().Type));
+    }
+
+    [TestCase(SerializationFormat.XML)]
+    [TestCase(SerializationFormat.Binary)]
+    [Test]
+    public void TestSessionIdIsCorrectlyDeserialized(SerializationFormat format)
+    {
+        // Arrange
+        TestSession session = new()
+        {
+            Url = new Uri("https://test"),
+            StartDate = DateTime.UtcNow,
+            State = TestSessionState.NotStarted,
+            Steps = []
+        };
+
+        var serializer = new TestSessionSerializer();
+        using var stream = new MemoryStream();
+
+        // Act
+        serializer.Serialize(session, stream, format);
+        stream.Position = 0;
+        TestSession? session1 = serializer.Deserialize(stream, format);
+
+        // Assert
+        Assert.That(session1, Is.Not.Null);
+        Assert.That(session.Id, Is.EqualTo(session1.Id));
     }
 
     [Test]

--- a/tests/XPing365.Sdk.Core.UnitTests/Session/TestSessionTests.cs
+++ b/tests/XPing365.Sdk.Core.UnitTests/Session/TestSessionTests.cs
@@ -33,6 +33,23 @@ public sealed class TestSessionTests
         };
 
     [Test]
+    public void ConstructorAssignsGUIDWhenAnObjectIsInstantiated()
+    {
+        // Act
+        var session = new TestSession
+        {
+            Url = new Uri("http://localhost"),
+            StartDate = DateTime.UtcNow,
+            Steps = [],
+            State = TestSessionState.NotStarted
+        };
+
+        // Assert
+        Assert.That(session.Id, Is.Not.EqualTo(Guid.Empty));
+    }
+
+
+    [Test]
     public void ThrowsArgumentNullExceptionWhenInstantiatedWithNullUri()
     {
         // Assert


### PR DESCRIPTION
**Description:** This pull request addresses Issue #33 by introducing a new `Id` property to the `TestSession` class, ensuring each session is uniquely identifiable through a GUID value. The addition of this property enhances the distinctiveness of each test session, making it easier to track and manage.

**Key Changes:**

- **New Property:** A Guid type Id property has been added with private set access, guaranteeing that once a `TestSession` object is created, its identifier remains immutable.

- **Serialization Consistency:** Modifications have been made to the serialization process to ensure the `Id` value is consistently preserved across serialization and deserialization operations.

This update is a crucial step towards improving the robustness of the `TestSession` management system, providing a solid foundation for future enhancements and maintenance.